### PR TITLE
restructured ExperimentData.from_yaml

### DIFF
--- a/src/f3dasm/design/domain.py
+++ b/src/f3dasm/design/domain.py
@@ -88,6 +88,20 @@ class Domain:
             args[space] = {name: instantiate(param, _convert_="all") for name, param in params.items()}
         return cls(**args)
 
+    @classmethod
+    def from_dataframe(cls, df: pd.DataFrame) -> 'Domain':
+        input_space = {}
+        for name, type in df.dtypes.items():
+            if type == 'float64':
+                input_space[name] = ContinuousParameter(lower_bound=float(
+                    df[name].min()), upper_bound=float(df[name].max()))
+            elif type == 'int64':
+                input_space[name] = DiscreteParameter(lower_bound=int(df[name].min()), upper_bound=int(df[name].max()))
+            else:
+                input_space[name] = CategoricalParameter(df[name].unique().tolist())
+
+        return cls(input_space=input_space)
+
     def store(self, filename: str) -> None:
         """Stores the Domain in a pickle file.
 

--- a/src/f3dasm/design/experimentdata.py
+++ b/src/f3dasm/design/experimentdata.py
@@ -151,9 +151,27 @@ class ExperimentData:
     @classmethod
     def from_csv(cls, filename_input: Path, filename_output: Union[None, Path] = None,
                  domain: Union[None, Domain] = None) -> 'ExperimentData':
+        """Create an ExperimentData object from input and output .csv files.
+
+        Parameters
+        ----------
+        filename_input : Path
+            filename of the input .csv file.
+        filename_output : Path, optional
+            filename of the output .csv file, by default None
+        domain : Domain, optional
+            Domain object, by default None
+
+        Returns
+        -------
+        ExperimentData
+            ExperimentData object containing the loaded data.
+        """
+        # Read the input datat csv file as a pandas dataframe
         df_input = pd.read_csv(filename_input.with_suffix('.csv'), index_col=0)
 
         if domain is None:
+            # Infer the domain from the input data
             domain = Domain.from_dataframe(df_input)
 
         experimentdata = cls(domain)
@@ -171,7 +189,18 @@ class ExperimentData:
 
     @classmethod
     def from_yaml(cls, config: DictConfig) -> 'ExperimentData':
+        """Create an ExperimentData object from a hydra yaml configuration.
 
+        Parameters
+        ----------
+        config : DictConfig
+            A DictConfig object containing the configuration.
+
+        Returns
+        -------
+        ExperimentData
+            ExperimentData object containing the loaded data.
+        """
         # Option 1: From exisiting ExperimentData files
         if 'from_file' in config.experimentdata:
             return cls.from_file(filename=config.experimentdata.from_file.filepath)

--- a/src/f3dasm/sampling/sampler.py
+++ b/src/f3dasm/sampling/sampler.py
@@ -44,12 +44,12 @@ class Sampler:
             np.random.seed(seed)
 
     @classmethod
-    def from_yaml(cls, config: DictConfig) -> 'Sampler':
+    def from_yaml(cls, domain_config: DictConfig, sampler_config: DictConfig) -> 'Sampler':
         """Create a sampler from a yaml configuration"""
 
-        args = {**config.sampler, 'design': None}
+        args = {**sampler_config, 'design': None}
         sampler: Sampler = instantiate(args)
-        sampler.design = Domain.from_yaml(config.design)
+        sampler.design = Domain.from_yaml(domain_config)
         return sampler
 
     def set_seed(self, seed: int):

--- a/tests/design/conftest.py
+++ b/tests/design/conftest.py
@@ -59,3 +59,13 @@ def design_data():
     dict_output = {'output1': 3, 'output2': 4}
     job_number = 123
     return dict_input, dict_output, job_number
+
+
+@pytest.fixture(scope="package")
+def sample_dataframe():
+    data = {
+        'feature1': [1.0, 2.0, 3.0],
+        'feature2': [4, 5, 6],
+        'feature3': ['A', 'B', 'C']
+    }
+    return pd.DataFrame(data)

--- a/tests/design/test_designofexperiments.py
+++ b/tests/design/test_designofexperiments.py
@@ -1,7 +1,7 @@
 import json
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 
 from f3dasm.design.domain import Domain
@@ -55,7 +55,7 @@ def test_add_arbitrary_list_as_categorical_parameter():
     arbitrary_list_2 = np.linspace(start=142, stop=214, num=10)
     designspace = {'x1': CategoricalParameter(categories=arbitrary_list_1),
                    'x2': CategoricalParameter(categories=arbitrary_list_2)
-    }
+                   }
 
     design = Domain(input_space=designspace)
 
@@ -150,6 +150,14 @@ def test_get_input_names(domain: Domain):
 def test_get_number_of_input_parameters(domain: Domain):
     # Ensure that get_number_of_input_parameters returns the correct number of input parameters
     assert domain.get_number_of_input_parameters() == 3
+
+
+def test_domain_from_dataframe(sample_dataframe: pd.DataFrame):
+    domain = Domain.from_dataframe(sample_dataframe)
+    ground_truth = Domain(input_space={'feature1': ContinuousParameter(lower_bound=1.0, upper_bound=3.0),
+                                       'feature2': DiscreteParameter(lower_bound=4, upper_bound=6),
+                                       'feature3': CategoricalParameter(['A', 'B', 'C'])})
+    assert (domain.input_space == ground_truth.input_space)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
added the following functionalities
- create a ExperimentData object from a csv file, and infer the domain automatically
- restructured the from_yaml constructer for ExperimentData to account for the 3 different construction options