### PR TITLE
added a failsafe when using int with continuous parameter

### DIFF
--- a/src/f3dasm/_src/design/parameter.py
+++ b/src/f3dasm/_src/design/parameter.py
@@ -77,9 +77,9 @@ class ContinuousParameter(Parameter):
 
     Attributes
     ----------
-    lower_bound : float, optional
+    lower_bound : float | int | str, optional
         The lower bound of the continuous search space. Defaults to negative infinity.
-    upper_bound : float, optional
+    upper_bound : float | int | str, optional
         The upper bound of the continuous search space (exclusive). Defaults to infinity.
     log : bool, optional
         Whether the search space is logarithmic. Defaults to False.
@@ -87,9 +87,11 @@ class ContinuousParameter(Parameter):
     Raises
     ------
     TypeError
-        If the boundaries are not floats.
+        If the boundaries are not floats, ints or strings.
     ValueError
-        If the upper bound is less than the lower bound, or if the lower bound is equal to the upper bound.
+        If the upper bound is less than the lower bound,
+        or if the lower bound is equal to the upper bound,
+        or if the strings cannot be converted to float.
 
     Notes
     -----
@@ -103,26 +105,25 @@ class ContinuousParameter(Parameter):
 
     def __post_init__(self):
 
+        self._check_types()
+        self._check_range()
+
         if self.log and self.lower_bound <= 0.0:
             raise ValueError(
                 f"The `lower_bound` value must be larger than 0 for a log distribution "
                 f"(low={self.lower_bound}, high={self.upper_bound})."
             )
-        
-        if isinstance(self.lower_bound, int):
-            self.lower_bound=float(self.lower_bound)
-        
-        if isinstance(self.upper_bound, int):
-            self.upper_bound=float(self.upper_bound)
-
-        self._check_types()
-        self._check_range()
 
     def _check_types(self):
         """Check if the boundaries are actually floats"""
-        if not isinstance(self.lower_bound, float) or not isinstance(self.upper_bound, float):
+        try:
+            self.lower_bound = float(self.lower_bound)
+            self.upper_bound = float(self.upper_bound)
+        except TypeError:
             raise TypeError(
-                f"Expect float, got {type(self.lower_bound)} and {type(self.upper_bound)}")
+                f"Expect float, int or str, got {type(self.lower_bound)} and {type(self.upper_bound)}")
+        except ValueError as e:
+            raise e
 
     def _check_range(self):
         """Check if the lower boundary is lower than the higher boundary"""

--- a/src/f3dasm/_src/design/parameter.py
+++ b/src/f3dasm/_src/design/parameter.py
@@ -108,6 +108,12 @@ class ContinuousParameter(Parameter):
                 f"The `lower_bound` value must be larger than 0 for a log distribution "
                 f"(low={self.lower_bound}, high={self.upper_bound})."
             )
+        
+        if isinstance(self.lower_bound, int):
+            self.lower_bound=float(self.lower_bound)
+        
+        if isinstance(self.upper_bound, int):
+            self.upper_bound=float(self.upper_bound)
 
         self._check_types()
         self._check_range()

--- a/tests/design/test_space.py
+++ b/tests/design/test_space.py
@@ -69,7 +69,7 @@ def test_invalid_types_arg2_int_continuous_space():
 def test_invalid_types_string_continuous_space():
     lower_bound = "lower bound"  # invalid string
     upper_bound = 1.5
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)
 
 

--- a/tests/design/test_space.py
+++ b/tests/design/test_space.py
@@ -20,8 +20,20 @@ def test_check_default_upper_bound():
     assert continuous.upper_bound == np.inf
 
 
-def test_correct_continuous_space():
+def test_correct_float_args_continuous_space():
     lower_bound = 3.3
+    upper_bound = 3.8
+    continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)
+
+
+def test_correct_int_args_continuous_space():
+    lower_bound = 3
+    upper_bound = 3.8
+    continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)
+
+
+def test_correct_int_args_continuous_space():
+    lower_bound = "3"
     upper_bound = 3.8
     continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)
 
@@ -41,7 +53,7 @@ def test_same_lower_and_upper_bound_continuous_space():
 
 
 def test_invalid_types_arg1_int_continuous_space():
-    lower_bound = 1  # int
+    lower_bound = [1.0,]  # list
     upper_bound = 1.5
     with pytest.raises(TypeError):
         continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)
@@ -49,13 +61,13 @@ def test_invalid_types_arg1_int_continuous_space():
 
 def test_invalid_types_arg2_int_continuous_space():
     lower_bound = 1.0
-    upper_bound = 2  # int
+    upper_bound = {"2": 2.0}  # dict
     with pytest.raises(TypeError):
         continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)
 
 
 def test_invalid_types_string_continuous_space():
-    lower_bound = "1"  # string
+    lower_bound = "lower bound"  # invalid string
     upper_bound = 1.5
     with pytest.raises(TypeError):
         continuous = ContinuousParameter(lower_bound=lower_bound, upper_bound=upper_bound)


### PR DESCRIPTION
Continuous parameter raises an error if used with integer bounds. However, integer could be used with the same behavior and simplify the the continuous parameter usage.