### PR TITLE
added different set_x0 selection modes

### DIFF
--- a/src/f3dasm/_src/optimization/optimizer.py
+++ b/src/f3dasm/_src/optimization/optimizer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 # Standard
 import sys
 from dataclasses import dataclass
-from typing import ClassVar, List, Optional, Tuple
+from typing import ClassVar, Iterable, List, Optional, Tuple
 
 if sys.version_info < (3, 8):  # NOQA
     from typing_extensions import Protocol  # NOQA
@@ -19,6 +19,7 @@ else:
 
 # Third-party core
 import numpy as np
+import pandas as pd
 
 # Locals
 from ..datageneration.datagenerator import DataGenerator
@@ -40,6 +41,10 @@ class ExperimentData(Protocol):
     input_data: _Data
     output_data: _Data
 
+    @property
+    def index(self, index) -> pd.Index:
+        ...
+
     def get_n_best_output(self, n_samples: int) -> ExperimentData:
         ...
 
@@ -50,6 +55,9 @@ class ExperimentData(Protocol):
         ...
 
     def empty() -> None:
+        ...
+
+    def select(self, indices: int | slice | Iterable[int]) -> ExperimentData:
         ...
 
 
@@ -127,10 +135,6 @@ class Optimizer:
     def _check_imports():
         ...
 
-    # def init_data(self):
-    #     """Set the data atrribute to an empty ExperimentData object"""
-    #     self.data = ExperimentData(self.domain)
-
     def set_algorithm(self):
         """Set the algorithm attribute to the algorithm of choice"""
         ...
@@ -167,16 +171,46 @@ class Optimizer:
         """Set the data attribute to the given data"""
         self.data = data
 
-    def set_x0(self, experiment_data: ExperimentData):
+    def set_x0(self, experiment_data: ExperimentData, mode: str):
         """Set the initial population to the best n samples of the given data
 
         Parameters
         ----------
         experiment_data : ExperimentData
             Data to be used for the initial population
+        mode : str
+            Mode of selecting the initial population, by default 'best'
 
+        Raises
+        ------
+        ValueError
+            Raises when the mode is not recognized
+
+        Notes
+        -----
+        The following modes are available:
+            - best: select the best n samples
+            - random: select n random samples
+            - last: select the last n samples
         """
-        x0 = experiment_data.get_n_best_output(self.hyperparameters.population)
+        if mode.lower() == 'best':
+            x0 = experiment_data.get_n_best_output(
+                self.hyperparameters.population)
+
+        elif mode.lower() == 'random':
+            x0 = experiment_data.select(
+                np.random.choice(
+                    experiment_data.index,
+                    self.hyperparameters.population, replace=False))
+
+        elif mode.lower() == 'last':
+            x0 = experiment_data.select(
+                experiment_data.index[-self.hyperparameters.population:])
+
+        else:
+            raise ValueError(
+                f'Unknown selection mode {mode}, use best, random or last')
+
         x0._reset_index()
         self.data = x0
 


### PR DESCRIPTION
Added different ways in which you can set x0 from initial samples for the optimizer:
The following x0_selections are available:
- 'best': Select the best designs from the current experimentdata
- 'random': Select random designs from the current experimentdata
- 'last': Select the last designs from the current experimentdata