### PR TITLE
Implement new x0_selection strategy and add select_all_finished functionality

### DIFF
--- a/src/f3dasm/_src/design/domain.py
+++ b/src/f3dasm/_src/design/domain.py
@@ -753,7 +753,6 @@ class Domain:
         """
         for output_name in names:
             if not self.is_in_output(output_name):
-                print(f"Output {output_name} not in domain. Adding it.")
                 self.add_output(output_name, to_disk=False)
 
     def is_in_output(self, output_name: str) -> bool:

--- a/src/f3dasm/_src/design/samplers.py
+++ b/src/f3dasm/_src/design/samplers.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 # Standard
 from itertools import product
-from typing import Optional
+from typing import Literal, Optional
 
 # Third-party
 import numpy as np
@@ -26,9 +26,11 @@ __status__ = 'Stable'
 #
 # =============================================================================
 
+SamplerNames = Literal['random', 'latin', 'sobol', 'grid']
 
 #                                                              Factory function
 # =============================================================================
+
 
 def _sampler_factory(sampler: str, domain: Domain) -> Sampler:
     if sampler.lower() == 'random':

--- a/src/f3dasm/_src/experimentdata/_data.py
+++ b/src/f3dasm/_src/experimentdata/_data.py
@@ -392,6 +392,16 @@ class _Data:
     def round(self, decimals: int):
         self.data = self.data.round(decimals=decimals)
 
+    def overwrite(self, indices: Iterable[int], other: _Data | Dict[str, Any]):
+        if isinstance(other, Dict):
+            other = _convert_dict_to_data(other)
+
+        for other_column in other.columns.names:
+            if other_column not in self.columns.names:
+                self.add_column(other_column)
+
+        self.data.update(other.data.set_index(pd.Index(indices)))
+
 #                                                           Getters and setters
 # =============================================================================
 

--- a/src/f3dasm/_src/experimentdata/_data.py
+++ b/src/f3dasm/_src/experimentdata/_data.py
@@ -236,7 +236,7 @@ class _Data:
         np.ndarray
             numpy array with the data.
         """
-        return self.data.to_numpy()
+        return self.data.to_numpy(dtype=np.float32)
 
     def to_xarray(self, label: str) -> xr.DataArray:
         """Export the _Data object to a xarray DataArray.

--- a/src/f3dasm/_src/experimentdata/_jobqueue.py
+++ b/src/f3dasm/_src/experimentdata/_jobqueue.py
@@ -63,7 +63,7 @@ class _JobQueue:
 
         self.jobs: pd.Series = jobs
 
-    def __add__(self, other: _JobQueue | int) -> _JobQueue:
+    def __add__(self, other: _JobQueue | str) -> _JobQueue:
         """Add two JobQueue objects together.
 
         Parameters
@@ -76,10 +76,10 @@ class _JobQueue:
         JobQueue
             JobQueue object containing the added jobs.
         """
-        if isinstance(other, int):
+        if isinstance(other, str):
             # make _JobQueue from the jobnumber
             other = _JobQueue(
-                pd.Series([Status.OPEN], index=[0], dtype='string'))
+                pd.Series(other, index=[0], dtype='string'))
 
         try:
             last_index = self.jobs.index[-1]
@@ -250,6 +250,16 @@ class _JobQueue:
             start=last_index + 1, stop=last_index + number_of_jobs + 1, step=1)
         jobs_to_add = pd.Series(status, index=new_indices, dtype='string')
         self.jobs = pd.concat([self.jobs, jobs_to_add], ignore_index=False)
+
+    def overwrite(
+            self, indices: Iterable[int],
+            other: _JobQueue | str) -> None:
+
+        if isinstance(other, str):
+            other = _JobQueue(
+                pd.Series([other], index=[0], dtype='string'))
+
+        self.jobs.update(other.jobs.set_axis(indices))
 
     #                                                                      Mark
     # =========================================================================

--- a/src/f3dasm/_src/experimentdata/_newdata.py
+++ b/src/f3dasm/_src/experimentdata/_newdata.py
@@ -640,6 +640,13 @@ class _Data:
         self.data = [[round(value, decimals) for value in row]
                      for row in self.data]
 
+    def overwrite(self, data: _Data, indices: Iterable[int]):
+        # TODO: Implement this method!
+        ...
+
+#                                                           Getters and setters
+# =============================================================================
+
     def get_data_dict(self, index: int) -> Dict[str, Any]:
         """
         Get the data as a dictionary.

--- a/src/f3dasm/_src/experimentdata/experimentdata.py
+++ b/src/f3dasm/_src/experimentdata/experimentdata.py
@@ -1183,7 +1183,8 @@ class ExperimentData:
 
     def optimize(self, optimizer: Optimizer | str,
                  data_generator: DataGenerator | str,
-                 iterations: int, kwargs: Optional[Dict[str, Any]] = None,
+                 iterations: int,
+                 kwargs: Optional[Dict[str, Any]] = None,
                  hyperparameters: Optional[Dict[str, Any]] = None,
                  x0_selection: Literal['best', 'random',
                                        'last',
@@ -1195,54 +1196,52 @@ class ExperimentData:
 
         Parameters
         ----------
-        optimizer : Optimizer
-            Optimizer object to use
+        optimizer : Optimizer | str
+            Optimizer object
         data_generator : DataGenerator | str
-            Data generator object to use
+            DataGenerator object
         iterations : int
-            Number of iterations to run
+            number of iterations
         kwargs : Dict[str, Any], optional
-            Any additional keyword arguments that need to be supplied to \
-            the data generator, by default None
+            any additional keyword arguments that will be passed to
+            the DataGenerator
         hyperparameters : Dict[str, Any], optional
-            Any additional hyperparameters that need to be supplied to the \
-            optimizer, by default None
-        x0_selection : str | ExperimentData, optional
-            How to select the initial design, by default 'best'
-        sampler : Sampler | str
-            Sampler to use, by default 'random'
-        overwrite : bool
-            If True, the optimizer will overwrite the current data,
-            by default False
+            any additional keyword arguments that will be passed to
+            the optimizer
+        x0_selection : str | ExperimentData
+            How to select the initial design. By default 'best'
+            The following x0_selections are available:
+
+            * 'best': Select the best designs from the current experimentdata
+            * 'random': Select random designs from the current experimentdata
+            * 'last': Select the last designs from the current experimentdata
+            * 'new': Create new random designs from the current experimentdata
+
+            If the x0_selection is 'new', new designs are sampled with the
+            sampler provided. The number of designs selected is equal to the
+            population size of the optimizer.
+
+            If an ExperimentData object is passed as x0_selection,
+            the optimizer will use the input_data and output_data from this
+            object as initial samples.
+        sampler: Sampler, optional
+            If x0_selection = 'new', the sampler to use. By default 'random'
+        overwrite: bool, optional
+            If True, the optimizer will overwrite the current data. By default
+            False
         callback : Callable, optional
-            A callback function that is called after every iteration,
-            by default None
+            A callback function that is called after every iteration. It has
+            the following signature:
+
+                    ``callback(intermediate_result: ExperimentData)``
+
+            where the first argument is a parameter containing an
+            `ExperimentData` object with the current iterate(s).
 
         Raises
         ------
         ValueError
             Raised when invalid x0_selection is specified
-        ValueError
-            Raised when invalid optimizer type is specified
-
-        Note
-        ----
-        The following x0_selections are available:
-
-        * 'best': Select the best designs from the current experimentdata
-        * 'random': Select random designs from the current experimentdata
-        * 'last': Select the last designs from the current experimentdata
-        * 'new': Create new random designs from the current experimentdata
-
-        If the x0_selection is 'new', new designs are sampled with the
-        sampler provided.
-
-        If an ExperimentData object is passed as x0_selection, the optimizer
-        will use the input_data and output_data from this object as initial
-        samples.
-
-        The number of designs selected is equal to the \
-        population size of the optimizer
         """
         # Create the data generator object if a string reference is passed
         if isinstance(data_generator, str):
@@ -1294,38 +1293,39 @@ class ExperimentData:
             any additional keyword arguments that will be passed to
             the DataGenerator
         x0_selection : str | ExperimentData
-            How to select the initial design
+            How to select the initial design.
+            The following x0_selections are available:
+
+            * 'best': Select the best designs from the current experimentdata
+            * 'random': Select random designs from the current experimentdata
+            * 'last': Select the last designs from the current experimentdata
+            * 'new': Create new random designs from the current experimentdata
+
+            If the x0_selection is 'new', new designs are sampled with the
+            sampler provided. The number of designs selected is equal to the
+            population size of the optimizer.
+
+            If an ExperimentData object is passed as x0_selection,
+            the optimizer will use the input_data and output_data from this
+            object as initial samples.
+
         sampler: Sampler
             If x0_selection = 'new', the sampler to use
         overwrite: bool
             If True, the optimizer will overwrite the current data.
         callback : Callable
-            A callback function that is called after every iteration,
-            by default None
+            A callback function that is called after every iteration. It has
+            the following signature:
+
+                    ``callback(intermediate_result: ExperimentData)``
+
+            where the first argument is a parameter containing an
+            `ExperimentData` object with the current iterate(s).
 
         Raises
         ------
         ValueError
             Raised when invalid x0_selection is specified
-
-        Note
-        ----
-        The following x0_selections are available:
-
-        * 'best': Select the best designs from the current experimentdata
-        * 'random': Select random designs from the current experimentdata
-        * 'last': Select the last designs from the current experimentdata
-        * 'new': Create new random designs from the current experimentdata
-
-        If the x0_selection is 'new', new designs are sampled with the
-        sampler provided.
-
-        If an ExperimentData object is passed as x0_selection, the optimizer
-        will use the input_data and output_data from this object as initial
-        samples.
-
-        The number of designs selected is equal to the
-        population size of the optimizer
         """
         if isinstance(x0_selection, str):
             if x0_selection == 'new':
@@ -1401,53 +1401,54 @@ class ExperimentData:
                        x0_selection: str | ExperimentData,
                        sampler: Sampler, overwrite: bool,
                        callback: Callable):
-        """Internal represenation of the iteration process for s
-        cipy-optimize algorithms
+        """Internal represenation of the iteration process for scipy-minimize
+        optimizers.
 
         Parameters
         ----------
-        optimizer : _Optimizer
+        optimizer : Optimizer
             Optimizer object
         data_generator : DataGenerator
             DataGenerator object
         iterations : int
             number of iterations
-        kwargs : dict, optional
-            any additional keyword arguments that will be passed
-            to the DataGenerator, by default None
-        x0_selection : str
-            How to select the initial design
+        kwargs : Dict[str, Any]
+            any additional keyword arguments that will be passed to
+            the DataGenerator
+        x0_selection : str | ExperimentData
+            How to select the initial design.
+            The following x0_selections are available:
+
+            * 'best': Select the best designs from the current experimentdata
+            * 'random': Select random designs from the current experimentdata
+            * 'last': Select the last designs from the current experimentdata
+            * 'new': Create new random designs from the current experimentdata
+
+            If the x0_selection is 'new', new designs are sampled with the
+            sampler provided. The number of designs selected is equal to the
+            population size of the optimizer.
+
+            If an ExperimentData object is passed as x0_selection,
+            the optimizer will use the input_data and output_data from this
+            object as initial samples.
+
         sampler: Sampler
             If x0_selection = 'new', the sampler to use
         overwrite: bool
             If True, the optimizer will overwrite the current data.
         callback : Callable
-            A callback function that is called after every optimization run,
-            by default None
+            A callback function that is called after every iteration. It has
+            the following signature:
+
+                    ``callback(intermediate_result: ExperimentData)``
+
+            where the first argument is a parameter containing an
+            `ExperimentData` object with the current iterate(s).
 
         Raises
         ------
         ValueError
             Raised when invalid x0_selection is specified
-
-        Note
-        ----
-        The following x0_selections are available:
-
-        * 'best': Select the best designs from the current experimentdata
-        * 'random': Select random designs from the current experimentdata
-        * 'last': Select the last designs from the current experimentdata
-        * 'new': Create new random designs from the current experimentdata
-
-        If the x0_selection is 'new', new designs are sampled with the
-        sampler provided.
-
-        If an ExperimentData object is passed as x0_selection, the optimizer
-        will use the input_data and output_data from this object as initial
-        samples.
-
-        The number of designs selected is equal to the
-        population size of the optimizer
         """
         n_data_before_iterate = len(self)
 
@@ -1524,21 +1525,18 @@ class ExperimentData:
 
         Parameters
         ----------
-        sampler
+        sampler: Sampler | str
             Sampler callable or string of built-in sampler
+            If a string is passed, it should be one of the built-in samplers:
+
+            * 'random' : Random sampling
+            * 'latin' : Latin Hypercube Sampling
+            * 'sobol' : Sobol Sequence Sampling
+            * 'grid' : Grid Search Sampling
         n_samples : int, optional
             Number of samples to generate, by default 1
         seed : Optional[int], optional
             Seed to use for the sampler, by default None
-
-        Note
-        ----
-        If a string is passed, it should be one of the built-in samplers:
-
-        * 'random' : Random sampling
-        * 'latin' : Latin Hypercube Sampling
-        * 'sobol' : Sobol Sequence Sampling
-        * 'grid' : Grid Search Sampling
 
         Raises
         ------

--- a/src/f3dasm/_src/experimentdata/experimentsample.py
+++ b/src/f3dasm/_src/experimentdata/experimentsample.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 # Standard
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Dict, Literal, Optional, Tuple, Type
 
 # Third-party
 import autograd.numpy as np
@@ -257,8 +257,24 @@ class ExperimentSample:
         """
         return self._jobnumber
 
+    @property
+    def jobs(self) -> Literal['finished', 'open']:
+        """Retrieve the job status.
+
+        Returns
+        -------
+        str
+            The job number of the design as a tuple.
+        """
+        # Check if the output contains values
+        if self._dict_output:
+            status = 'finished'
+        else:
+            status = 'open'
+
+        return status
+
     # Alias
-    jobs = job_number
     _jobs = jobs
 
 #                                                                        Export

--- a/src/f3dasm/_src/experimentdata/experimentsample.py
+++ b/src/f3dasm/_src/experimentdata/experimentsample.py
@@ -195,7 +195,7 @@ class ExperimentSample:
         self._dict_output[key] = (value, False)
 
     def __repr__(self) -> str:
-        return (f"ExperimentSample({self.job_number} :"
+        return (f"ExperimentSample({self.job_number} ({self.jobs}) :"
                 f"{self.input_data} - {self.output_data})")
 
     @property
@@ -266,8 +266,10 @@ class ExperimentSample:
         str
             The job number of the design as a tuple.
         """
-        # Check if the output contains values
-        if self._dict_output:
+        # Check if the output contains values or not all nan
+        has_all_nan = np.all(np.isnan(list(self._output_data.values())))
+
+        if self._output_data and not has_all_nan:
             status = 'finished'
         else:
             status = 'open'

--- a/src/f3dasm/_src/optimization/adapters/scipy_implementations.py
+++ b/src/f3dasm/_src/optimization/adapters/scipy_implementations.py
@@ -24,7 +24,7 @@ class _SciPyOptimizer(Optimizer):
     type: str = 'scipy'
 
     def _callback(self, xk: np.ndarray, *args, **kwargs) -> None:
-        self.data._add_experiments(
+        self.data.add_experiments(
             ExperimentSample.from_numpy(xk, domain=self.domain))
 
     def update_step(self):

--- a/src/f3dasm/_src/optimization/optimizer.py
+++ b/src/f3dasm/_src/optimization/optimizer.py
@@ -159,6 +159,9 @@ class Optimizer:
         """Set the data attribute to the given data"""
         self.data = data
 
+    def add_experiments(self, experiments: ExperimentData):
+        ...
+
     def set_x0(self, experiment_data: ExperimentData,
                mode: str | ExperimentData):
         """Set the initial population to the best n samples of the given data

--- a/src/f3dasm/_src/optimization/optimizer.py
+++ b/src/f3dasm/_src/optimization/optimizer.py
@@ -159,7 +159,8 @@ class Optimizer:
         """Set the data attribute to the given data"""
         self.data = data
 
-    def set_x0(self, experiment_data: ExperimentData, mode: str):
+    def set_x0(self, experiment_data: ExperimentData,
+               mode: str | ExperimentData):
         """Set the initial population to the best n samples of the given data
 
         Parameters
@@ -181,7 +182,10 @@ class Optimizer:
             - random: select n random samples
             - last: select the last n samples
         """
-        if mode.lower() == 'best':
+        if isinstance(mode, ExperimentData):
+            x0 = mode
+
+        elif mode.lower() == 'best':
             x0 = experiment_data.get_n_best_output(
                 self.hyperparameters.population)
 

--- a/src/f3dasm/design.py
+++ b/src/f3dasm/design.py
@@ -9,6 +9,7 @@ from ._src.design.domain import Domain, make_nd_continuous_domain
 from ._src.design.parameter import (PARAMETERS, _CategoricalParameter,
                                     _ConstantParameter, _ContinuousParameter,
                                     _DiscreteParameter, _Parameter)
+from ._src.design.samplers import Sampler, SamplerNames
 from ._src.experimentdata._data import _Data
 from ._src.experimentdata._jobqueue import NoOpenJobsError, Status, _JobQueue
 
@@ -34,4 +35,6 @@ __all__ = [
     'Status',
     '_Data',
     '_JobQueue',
+    'Sampler',
+    'SamplerNames',
 ]

--- a/tests/design/test_data.py
+++ b/tests/design/test_data.py
@@ -99,3 +99,26 @@ def test_compatible_columns_add():
     g = _Data(dg)
 
     _ = f + g
+
+
+def test_overwrite_data(sample_data: _Data):
+    overwrite_data = _Data(pd.DataFrame(
+        {'input1': [5, 6, 7], 'input2': [8, 9, 10]}))
+
+    sample_data.overwrite(other=overwrite_data, indices=[0, 1, 2])
+
+    pd.testing.assert_frame_equal(sample_data.data, overwrite_data.data,
+                                  check_dtype=False, atol=1e-6)
+
+
+def test_overwrite_data2(sample_data: _Data):
+    overwrite_data = _Data(pd.DataFrame(
+        {'input1': [5, 6, ], 'input2': [8, 9]}))
+
+    sample_data.overwrite(other=overwrite_data, indices=[1, 2])
+
+    ground_truth = _Data(pd.DataFrame(
+        {'input1': [1, 5, 6], 'input2': [4, 8, 9]}))
+
+    pd.testing.assert_frame_equal(sample_data.data, ground_truth.data,
+                                  check_dtype=False, atol=1e-6)

--- a/tests/design/test_jobqueue.py
+++ b/tests/design/test_jobqueue.py
@@ -1,14 +1,17 @@
+from typing import Iterable
+
 import pandas as pd
 import pytest
 
-from f3dasm.design import NoOpenJobsError, _JobQueue, Status
+from f3dasm.design import NoOpenJobsError, Status, _JobQueue
 
 pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture
 def sample_job_queue():
-    jobs = pd.Series(['open', 'open', 'in progress', 'finished'], dtype='string')
+    jobs = pd.Series(['open', 'open', 'in progress',
+                     'finished'], dtype='string')
     job_queue = _JobQueue(jobs)
 
     yield job_queue
@@ -29,16 +32,19 @@ def test_job_queue_initialization(sample_job_queue: _JobQueue):
 def test_job_queue_repr_html(sample_job_queue: _JobQueue):
     assert isinstance(sample_job_queue._repr_html_(), str)
 
+
 def test_job_queue_remove(sample_job_queue: _JobQueue):
     sample_job_queue.remove([1, 3])
-    expected_jobs = pd.Series(['open', 'in progress'], index=[0, 2], dtype='string')
+    expected_jobs = pd.Series(['open', 'in progress'], index=[
+                              0, 2], dtype='string')
     assert sample_job_queue.jobs.equals(expected_jobs)
 
 
 def test_job_queue_add():
     job_queue = _JobQueue()
     job_queue.add(5, 'open')
-    assert job_queue.jobs.equals(pd.Series(['open', 'open', 'open', 'open', 'open'], dtype='string'))
+    assert job_queue.jobs.equals(
+        pd.Series(['open', 'open', 'open', 'open', 'open'], dtype='string'))
 
 
 def test_job_queue_reset(sample_job_queue: _JobQueue):
@@ -53,7 +59,8 @@ def test_job_queue_get_open_job(sample_job_queue: _JobQueue):
 
 
 def test_job_queue_get_open_job_no_jobs():
-    jobs = pd.Series(['finished', 'finished', 'in progress', 'finished'], dtype='string')
+    jobs = pd.Series(['finished', 'finished', 'in progress',
+                     'finished'], dtype='string')
     job_queue = _JobQueue(jobs)
     with pytest.raises(NoOpenJobsError):
         job_queue.get_open_job()
@@ -79,7 +86,8 @@ def test_job_queue_mark_as_error(sample_job_queue: _JobQueue):
 
 def test_job_queue_mark_all_in_progress_open(sample_job_queue: _JobQueue):
     sample_job_queue.mark_all_in_progress_open()
-    assert sample_job_queue.jobs.equals(pd.Series(['open', 'open', 'open', 'finished'], dtype='string'))
+    assert sample_job_queue.jobs.equals(
+        pd.Series(['open', 'open', 'open', 'finished'], dtype='string'))
 
 
 def test_job_queue_is_all_finished(sample_job_queue: _JobQueue):


### PR DESCRIPTION
- Implement a new `x0_selection` strategy that samples new samples for the initial population. 
- Also, add a `.select_all_finished` method to `ExperimentData` to only display experiments that are successfully finished.
- Implement method to overwrite current decision vector instead of storing all of the history for optimization
- added callback functionality to optimizers


Fixes #248, #250, #259, #261