### PR TITLE
Move scratch_dir from SlurmCluster to Pipeline.run() rootdir parameter

### DIFF
--- a/src/f3dasm/_src/pipeline/executors/base.py
+++ b/src/f3dasm/_src/pipeline/executors/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 # Standard
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 # Local
@@ -32,6 +33,7 @@ class Executor(ABC):
         self,
         pipeline: Pipeline,
         project_job: str | None = None,
+        rootdir: Path | None = None,
     ) -> str:
         """Execute a pipeline and return the project job ID.
 
@@ -42,6 +44,10 @@ class Executor(ABC):
         project_job : str, optional
             Existing project job ID for resumption. If ``None``,
             a timestamp-based ID is generated.
+        rootdir : Path, optional
+            Root directory under which the job folder is created
+            (``rootdir / project_job``). Defaults to the current
+            working directory.
 
         Returns
         -------

--- a/src/f3dasm/_src/pipeline/executors/local.py
+++ b/src/f3dasm/_src/pipeline/executors/local.py
@@ -55,6 +55,7 @@ class LocalExecutor(Executor):
         self,
         pipeline: Pipeline,
         project_job: str | None = None,
+        rootdir: Path | None = None,
     ) -> str:
         """Execute the pipeline locally.
 
@@ -63,15 +64,19 @@ class LocalExecutor(Executor):
         pipeline : Pipeline
             The pipeline to execute.
         project_job : str, optional
-            Job identifier used as the run folder (``cwd / project_job``).
-            Defaults to a timestamp-based ID.
+            Job identifier used as the run folder
+            (``rootdir / project_job``). Defaults to a
+            timestamp-based ID.
+        rootdir : Path, optional
+            Root directory under which the job folder is created.
+            Defaults to the current working directory.
 
         Returns
         -------
         str
             The project job ID.
         """
-        rootdir: Path = Path.cwd()
+        rootdir = rootdir if rootdir is not None else Path.cwd()
         resolved_job: str = project_job or str(int(time.time()))
         job_dir: Path = rootdir / resolved_job
         job_dir.mkdir(parents=True, exist_ok=True)

--- a/src/f3dasm/_src/pipeline/executors/slurm.py
+++ b/src/f3dasm/_src/pipeline/executors/slurm.py
@@ -62,6 +62,7 @@ class SlurmExecutor(Executor):
         self,
         pipeline: Pipeline,
         project_job: str | None = None,
+        rootdir: Path | None = None,
     ) -> str:
         """Submit the pipeline to SLURM.
 
@@ -76,15 +77,18 @@ class SlurmExecutor(Executor):
             The pipeline to execute.
         project_job : str, optional
             Job identifier used as the run folder
-            (``scratch_dir / project_job``). If ``None``, a
+            (``rootdir / project_job``). If ``None``, a
             timestamp-based ID is generated.
+        rootdir : Path, optional
+            Root directory under which the job folder is created.
+            Defaults to the current working directory.
 
         Returns
         -------
         str
             The project job ID.
         """
-        rootdir: Path = Path(self.cluster.scratch_dir)
+        rootdir = rootdir if rootdir is not None else Path.cwd()
         resolved_job: str = project_job or str(int(time.time()))
 
         # job_dir holds all pipeline artifacts (.pipeline.pkl,
@@ -166,6 +170,7 @@ class SlurmExecutor(Executor):
         self,
         pipeline: Pipeline,
         project_job: str = "PLACEHOLDER",
+        rootdir: Path | None = None,
     ) -> dict[str, str]:
         """Generate SLURM scripts without submitting.
 
@@ -179,13 +184,16 @@ class SlurmExecutor(Executor):
             The pipeline to generate scripts for.
         project_job : str
             Placeholder project job ID.
+        rootdir : Path, optional
+            Root directory under which the job folder is created.
+            Defaults to the current working directory.
 
         Returns
         -------
         dict[str, str]
             Mapping of label to rendered script content.
         """
-        rootdir: Path = Path(self.cluster.scratch_dir)
+        rootdir = rootdir if rootdir is not None else Path.cwd()
         job_dir: Path = rootdir / project_job
         log_dir_path: str = str(job_dir / "logs")
 

--- a/src/f3dasm/_src/pipeline/pipeline.py
+++ b/src/f3dasm/_src/pipeline/pipeline.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 # Local
@@ -147,8 +148,8 @@ class Pipeline:
             cluster=SlurmCluster(
                 partition="batch",
                 account="my_account",
-                scratch_dir="/scratch/user",
             ),
+            rootdir="/scratch/user",
         )
     """
 
@@ -185,6 +186,7 @@ class Pipeline:
         mode: Literal["local", "slurm"] = "local",
         cluster: SlurmCluster | None = None,
         project_job: str | None = None,
+        rootdir: Path | str | None = None,
     ) -> str:
         """Execute the pipeline.
 
@@ -200,6 +202,9 @@ class Pipeline:
             (``rootdir / project_job``). Defaults to
             ``str(int(time.time()))``. Pass an existing ID to
             resume a previous run.
+        rootdir : Path | str, optional
+            Root directory under which the job folder is created.
+            Defaults to the current working directory.
 
         Returns
         -------
@@ -210,6 +215,8 @@ class Pipeline:
         # pipeline -> executors -> pipeline
         from .executors.local import LocalExecutor
         from .executors.slurm import SlurmExecutor
+
+        _rootdir: Path | None = Path(rootdir) if rootdir is not None else None
 
         if mode == "local":
             executor = LocalExecutor()
@@ -225,12 +232,14 @@ class Pipeline:
         return executor.run(
             pipeline=self,
             project_job=project_job,
+            rootdir=_rootdir,
         )
 
     def generate_scripts(
         self,
         cluster: SlurmCluster,
         project_job: str = "PLACEHOLDER",
+        rootdir: Path | str | None = None,
     ) -> dict[str, str]:
         """Generate SLURM scripts without submitting them.
 
@@ -245,6 +254,9 @@ class Pipeline:
             Cluster configuration.
         project_job : str
             Project job ID to embed in scripts.
+        rootdir : Path | str, optional
+            Root directory under which the job folder is created.
+            Defaults to the current working directory.
 
         Returns
         -------
@@ -253,8 +265,10 @@ class Pipeline:
         """
         from .executors.slurm import SlurmExecutor
 
+        _rootdir: Path | None = Path(rootdir) if rootdir is not None else None
         executor = SlurmExecutor(cluster=cluster)
         return executor.generate_scripts(
             pipeline=self,
             project_job=project_job,
+            rootdir=_rootdir,
         )

--- a/src/f3dasm/_src/pipeline/resources.py
+++ b/src/f3dasm/_src/pipeline/resources.py
@@ -61,8 +61,6 @@ class SlurmCluster:
         SLURM partition name.
     account : str
         SLURM account string.
-    scratch_dir : str
-        Absolute path to the scratch directory on this cluster.
     env_setup : list[str]
         Shell commands to run before the Python command
         (e.g. module loads, ``unset LD_LIBRARY_PATH``).
@@ -77,7 +75,6 @@ class SlurmCluster:
 
     partition: str = "batch"
     account: str = "default"
-    scratch_dir: str = "."
     env_setup: list[str] = field(default_factory=list)
     env_vars: dict[str, str] = field(default_factory=dict)
     runner: str = "python"


### PR DESCRIPTION
## Summary
Refactors the pipeline execution API to move the scratch directory configuration from the `SlurmCluster` resource class to a `rootdir` parameter in the `Pipeline.run()` and `Pipeline.generate_scripts()` methods. This decouples cluster configuration from job directory management and provides more flexibility in specifying where pipeline artifacts are stored.

## Key Changes

- **Removed `scratch_dir` from `SlurmCluster`**: The `scratch_dir` field is no longer part of cluster configuration, simplifying the cluster resource definition.

- **Added `rootdir` parameter to `Pipeline.run()`**: New optional parameter that specifies the root directory under which job folders are created. Defaults to the current working directory if not provided.

- **Added `rootdir` parameter to `Pipeline.generate_scripts()`**: Consistent with `run()`, allows specifying the root directory for script generation.

- **Updated executor implementations**: Both `LocalExecutor` and `SlurmExecutor` now accept and use the `rootdir` parameter instead of deriving it from cluster configuration or hardcoding to current directory.

- **Updated base executor interface**: The abstract `Executor.run()` method signature now includes the `rootdir` parameter with proper documentation.

- **Updated docstrings and examples**: Documentation reflects the new API, including the example in the docstring that now shows `rootdir` as a parameter to `Pipeline.run()` instead of `scratch_dir` in the cluster configuration.

## Implementation Details

- The `rootdir` parameter is converted to a `Path` object in the pipeline methods before passing to executors, with `None` values defaulting to `Path.cwd()` at the executor level.
- Added `from pathlib import Path` import to `pipeline.py` and `base.py` where needed.
- The change maintains backward compatibility for local execution while providing clearer semantics for SLURM job directory placement.

https://claude.ai/code/session_015uFGSUaSXHYa5QpiUB32qp