### PR TITLE
docs: clarify StoreFunction must return path with file extension

### DIFF
--- a/docs/notebooks/design/domain_creation.ipynb
+++ b/docs/notebooks/design/domain_creation.ipynb
@@ -220,27 +220,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Storing parameters on disk\n",
-    "\n",
-    "As you will see in the next section, ?the `ExperimentData` object stores data associated with parameters. The data is stored in a tabular format, where each row corresponds to a single evaluation of the designspace. The columns of the table correspond to the input parameters and the output values.\n",
-    "\n",
-    "Sometimes it is wise to store the data associated with a parameter separately outside this table:\n",
-    "- when the data associated with a parameter is very large (e.g., large arrays or matrices), it allows you to lazy-load the data when needed\n",
-    "- when the data should not or cannot be casted to a `.csv` file (e.g., a custom object)\n",
-    "\n",
-    "You can choose to only store a reference in the `ExperimentData` object and store the data on disk. This can be done by setting the `to_disk` parameter to `True` when adding the parameter to the domain.\n",
-    "\n",
-    "`f3dasm` supports storing and loading data for a few commonly used data types:\n",
-    "\n",
-    "- numpy arrays\n",
-    "- pandas dataframes\n",
-    "- xarray datasets and data arrays\n",
-    "\n",
-    "For any other data types, you have to define custom functions to store and load data. These functions should take the data as input and return a string that can be used to identify the data when loading it. You can define these functions using the `store_function` and `load_function` parameters when adding the parameter to the domain.\n",
-    "\n",
-    "The following example demonstrates how to store and load a numpy array to and from disk. We will use a custom store and load function for this example, but these functions are not necessary for numpy arrays, as `f3dasm` provides built-in support for storing and loading numpy arrays:"
-   ]
+   "source": "### Storing parameters on disk\n\nAs you will see in the next section, the `ExperimentData` object stores data associated with parameters. The data is stored in a tabular format, where each row corresponds to a single evaluation of the designspace. The columns of the table correspond to the input parameters and the output values.\n\nSometimes it is wise to store the data associated with a parameter separately outside this table:\n- when the data associated with a parameter is very large (e.g., large arrays or matrices), it allows you to lazy-load the data when needed\n- when the data should not or cannot be casted to a `.csv` file (e.g., a custom object)\n\nYou can choose to only store a reference in the `ExperimentData` object and store the data on disk. This can be done by setting the `to_disk` parameter to `True` when adding the parameter to the domain.\n\n`f3dasm` supports storing and loading data for a few commonly used data types:\n\n- numpy arrays\n- pandas dataframes\n- xarray datasets and data arrays\n\nFor any other data types, you have to define custom functions to store and load data. You can attach these to a parameter via the `store_function` and `load_function` arguments of `add_parameter` / `add_output`.\n\nA custom `store_function` receives the object together with a `path` **without a file extension**, and is responsible for picking the appropriate suffix, writing the object, and returning the full path **including that extension**. f3dasm uses the returned path verbatim to locate the object at load time, so the suffix on disk and in the return value must match. The matching `load_function` receives that same full path (with the extension) and returns the loaded object.\n\nThe following example demonstrates how to store and load a numpy array to and from disk. We will use a custom store and load function for this example, but these functions are not necessary for numpy arrays, as `f3dasm` provides built-in support for storing and loading numpy arrays:"
   },
   {
    "cell_type": "code",

--- a/src/f3dasm/_src/design/parameter.py
+++ b/src/f3dasm/_src/design/parameter.py
@@ -29,44 +29,71 @@ CategoricalType = Union[None, int, float, str]  # noqa
 
 
 class StoreFunction(Protocol):
-    """Base class for storing and loading output data from disk"""
+    """Protocol for a custom function that stores an object to disk."""
 
     def __call__(object: Any, path: str) -> str:
         """
-        Protocol class for storing output data from disk.
+        Store ``object`` to disk and return the full path it was written to.
 
         Parameters
         ----------
         object : Any
             The object to store.
         path : str
-            The location to store the object to.
+            The location to store the object to, **without** a file
+            extension. The implementation is responsible for choosing the
+            extension appropriate to the object type and appending it
+            before writing.
 
-        Notes
-        -----
-        The function should store the object to the location specified by the
-        path parameter. The suffix of the file should be determined by the
-        object type, and is not yet implemented in the path!
+        Returns
+        -------
+        str
+            The full path the object was written to, **including** the
+            file extension. f3dasm uses this returned path to locate the
+            object at load time, so it must reflect the extension actually
+            used on disk.
+
+        Examples
+        --------
+        A minimal store function for a numpy array — note that the
+        returned path carries the ``.npy`` suffix:
+
+        >>> import numpy as np
+        >>> from pathlib import Path
+        >>> def numpy_store(object: np.ndarray, path: str) -> str:
+        ...     _path = Path(path).with_suffix(".npy")
+        ...     np.save(_path, object)
+        ...     return str(_path)  # must include the .npy suffix
         """
         ...
 
 
 class LoadFunction(Protocol):
-    """Base class for storing and loading output data from disk"""
+    """Protocol for a custom function that loads an object from disk."""
 
     def __call__(path: str) -> Any:
         """
-        Protocol class for loading output data from disk.
+        Load and return the object previously written by a StoreFunction.
 
         Parameters
         ----------
         path : str
-            The location to load the object from.
+            The full path the object was written to, **including** the
+            file extension. This is the value the matching
+            :class:`StoreFunction` returned.
 
         Returns
         -------
         Any
             The loaded object.
+
+        Examples
+        --------
+        The symmetric load for the numpy ``StoreFunction`` example:
+
+        >>> import numpy as np
+        >>> def numpy_load(path: str) -> np.ndarray:
+        ...     return np.load(path)
         """
         ...
 


### PR DESCRIPTION
## Summary
- Rewrites the `StoreFunction` and `LoadFunction` Protocol docstrings in `src/f3dasm/_src/design/parameter.py` to explicitly state the path-extension contract: the input `path` arrives without a suffix and the implementation must return the full path **including** the suffix it actually wrote.
- Adds a worked numpy example in each docstring showing the symmetric store/load pair.
- Updates the matching prose in `docs/notebooks/design/domain_creation.ipynb` so the same contract is visible in the rendered mkdocs tutorial (the prior wording said the function should return "a string that can be used to identify the data").

## Test plan
- [x] `uv run pytest tests/design/` — 112 passed (no runtime change; docstring-only)
- [x] `uv run mkdocs build` — clean, new paragraph renders in `notebooks/design/domain_creation/index.html`
- [x] `uv run pre-commit run --files src/f3dasm/_src/design/parameter.py docs/notebooks/design/domain_creation.ipynb` — ruff format + check pass

Fix #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)