### PR TITLE
fix: avoid materializing full range when sampling discrete params

### DIFF
--- a/src/f3dasm/_src/samplers.py
+++ b/src/f3dasm/_src/samplers.py
@@ -167,14 +167,28 @@ def random_sample_discrete_parameters(
     samples = {}
     for i in range(n_samples):
         sample_values = {
-            name: rng.choice(
-                range(param.lower_bound, param.upper_bound + 1, param.step)
-            )
+            name: _random_int_in_range(rng, param)
             for name, param in input_space.items()
         }
         samples[i] = ExperimentSample(_input_data=sample_values)
 
     return samples
+
+
+def _random_int_in_range(
+    rng: np.random.Generator, param: DiscreteParameter
+) -> np.integer:
+    """Draw one int from `[lower_bound, upper_bound]` honoring ``step``.
+
+    Avoids ``rng.choice(range(...))`` which materializes the full range
+    into an array — that pattern OOMs for parameters with very large
+    bounds (see issue #270).
+    """
+    if param.step == 1:
+        return rng.integers(low=param.lower_bound, high=param.upper_bound + 1)
+    # Sample an offset in [0, span) and scale by step.
+    span = (param.upper_bound - param.lower_bound) // param.step + 1
+    return param.lower_bound + param.step * rng.integers(low=0, high=span)
 
 
 def random_sample_categorical_parameters(

--- a/tests/sampling/test_sampling_extended.py
+++ b/tests/sampling/test_sampling_extended.py
@@ -172,6 +172,52 @@ def test_sampler_discrete_only():
         assert 0 <= int(val) <= 10
 
 
+def test_sampler_discrete_large_bound_bounded_memory():
+    # Regression for issue #270: the random sampler used to do
+    # `rng.choice(range(low, high+1, step))`, which materializes the full
+    # range into a numpy array and OOMs for high ~ 1e12. The replacement
+    # uses `rng.integers` directly and must run in bounded memory while
+    # still producing values inside the domain.
+    import tracemalloc
+
+    upper = int(1e12)
+    domain = Domain()
+    domain.add_int("x", low=0, high=upper)
+    data = ExperimentData(domain=domain)
+    sampler = create_sampler(sampler="random", seed=2024)
+
+    tracemalloc.start()
+    result = sampler.call(data=data, n_samples=4)
+    _current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # The bug allocated O((high-low)/step) bytes; with high == 1e12 that
+    # is many gigabytes. A correct implementation only needs a few KB for
+    # the 4 sampled values. Set the cap generously (8 MB) so the test
+    # stays portable while still proving the bug is gone.
+    assert peak < 8 * 1024 * 1024
+    df, _ = result.to_pandas()
+    for val in df["x"]:
+        assert 0 <= int(val) <= upper
+
+
+def test_sampler_discrete_with_step():
+    # The step != 1 code path is exercised here so that the inverse-step
+    # arithmetic stays correct (#270 fix).
+    domain = Domain()
+    domain.add_int(
+        "x", low=4, high=20, step=3
+    )  # legal grid: 4, 7, 10, 13, 16, 19
+    data = ExperimentData(domain=domain)
+    sampler = create_sampler(sampler="random", seed=42)
+    result = sampler.call(data=data, n_samples=20)
+
+    df, _ = result.to_pandas()
+    legal = {4, 7, 10, 13, 16, 19}
+    for val in df["x"]:
+        assert int(val) in legal
+
+
 def test_sampler_categorical_only():
     domain = Domain()
     domain.add_category("cat", ["a", "b", "c"])


### PR DESCRIPTION
## Summary
- `random_sample_discrete_parameters` previously drew each sample via `rng.choice(range(low, high+1, step))`. `numpy.random.Generator.choice` materializes the full population, so memory grew with the span of the parameter; `Domain.add_int(name='x', low=0, high=int(1e12))` OOMed before any sample was returned.
- Replaces the call with `rng.integers` (no population array) through a `_random_int_in_range` helper. `step == 1` uses `rng.integers(low, high+1)` directly; the strided path samples an offset in `[0, span)` and scales by `step`, producing the same discrete set as before.

## Test plan
- [x] `uv run pytest tests/sampling/ --no-cov` — 56 passed
- [x] New `test_sampler_discrete_large_bound_bounded_memory` uses `tracemalloc` to assert peak < 8 MB for `high == 1e12` (the buggy implementation OOMed)
- [x] New `test_sampler_discrete_with_step` locks in the strided path against the legal grid
- [x] Original repro from issue body now returns a valid in-range sample without OOM
- [x] `uv run pre-commit run --files src/f3dasm/_src/samplers.py tests/sampling/test_sampling_extended.py` — clean

Fix #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)