### PR TITLE
fix: atomically write store files to avoid EmptyDataError races

### DIFF
--- a/src/f3dasm/_src/_io.py
+++ b/src/f3dasm/_src/_io.py
@@ -55,6 +55,39 @@ MAX_TRIES = 20
 # =============================================================================
 
 
+def _atomic_write(target: Path, write_fn: Callable[[Path], None]) -> str:
+    """Write to a sibling ``.tmp`` file then POSIX-atomically rename.
+
+    Some f3dasm pipelines run many parallel writers (SLURM array jobs,
+    ``evaluate_multiprocessing``) against a single project directory while
+    a separate driver process reads the same file via ``from_file``. The
+    naive ``to_csv(path)`` / ``np.save(path)`` patterns truncate the
+    target first and then stream the body, so a concurrent reader can
+    catch the file half-written and raise ``pd.errors.EmptyDataError``
+    (see issue #273).
+
+    Writing to a sibling temp path and then calling ``Path.replace`` (an
+    ``os.rename``) means readers always see either the previous fully
+    written file or the new one — never an empty or partial file.
+
+    Parameters
+    ----------
+    target : Path
+        Final path the object should live at (including extension).
+    write_fn : Callable[[Path], None]
+        Callable that writes the object to the path it receives.
+
+    Returns
+    -------
+    str
+        The string form of ``target`` (always with the chosen extension).
+    """
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    write_fn(tmp)
+    tmp.replace(target)
+    return str(target)
+
+
 def pickle_store(object: Any, path: str) -> str:
     """
     Store an object using pickle.
@@ -72,10 +105,12 @@ def pickle_store(object: Any, path: str) -> str:
         The path to the stored object.
     """
     _path = Path(path).with_suffix(".pkl")
-    with open(_path, "wb") as file:
-        pickle.dump(object, file)
 
-    return str(_path)
+    def _write(p: Path) -> None:
+        with open(p, "wb") as file:
+            pickle.dump(object, file)
+
+    return _atomic_write(_path, _write)
 
 
 def pickle_load(path: str) -> Any:
@@ -114,8 +149,14 @@ def numpy_store(object: np.ndarray, path: str) -> str:
         The path to the stored array.
     """
     _path = Path(path).with_suffix(".npy")
-    np.save(file=_path, arr=object)
-    return str(_path)
+
+    def _write(p: Path) -> None:
+        # Pass an open file handle so np.save does not auto-append ".npy"
+        # to the temp path (which would otherwise become "<name>.npy.tmp.npy").
+        with open(p, "wb") as file:
+            np.save(file, object)
+
+    return _atomic_write(_path, _write)
 
 
 def numpy_load(path: str) -> np.ndarray:
@@ -153,8 +194,7 @@ def pandas_store(object: pd.DataFrame, path: str) -> str:
         The path to the stored DataFrame.
     """
     _path = Path(path).with_suffix(".csv")
-    object.to_csv(_path)
-    return str(_path)
+    return _atomic_write(_path, lambda p: object.to_csv(p))
 
 
 def pandas_load(path: str) -> pd.DataFrame:
@@ -192,8 +232,7 @@ def xarray_dataset_store(object: xr.DataArray | xr.Dataset, path: str) -> str:
         The path to the stored object.
     """
     _path = Path(path).with_suffix(".ncs")
-    object.to_netcdf(_path)
-    return str(_path)
+    return _atomic_write(_path, lambda p: object.to_netcdf(p))
 
 
 def xarray_dataarray_store(
@@ -215,8 +254,7 @@ def xarray_dataarray_store(
         The path to the stored object.
     """
     _path = Path(path).with_suffix(".nca")
-    object.to_netcdf(_path)
-    return str(_path)
+    return _atomic_write(_path, lambda p: object.to_netcdf(p))
 
 
 def xarray_dataset_load(path: str) -> xr.DataArray | xr.Dataset:
@@ -275,15 +313,17 @@ def figure_store(object: plt.Figure, path: str) -> str:
     """
     _path = Path(path)
 
-    object.savefig(
-        _path.with_suffix(".pdf"),
-        format="pdf",
-        bbox_inches="tight",
-        pad_inches=0.01,
-        transparent=True,
-        dpi=RESOLUTION_MATPLOTLIB_FIGURE,
-    )
+    def _write(p: Path) -> None:
+        object.savefig(
+            p,
+            format="pdf",
+            bbox_inches="tight",
+            pad_inches=0.01,
+            transparent=True,
+            dpi=RESOLUTION_MATPLOTLIB_FIGURE,
+        )
 
+    _atomic_write(_path.with_suffix(".pdf"), _write)
     return str(_path)
 
 

--- a/tests/experimentdata/test_io.py
+++ b/tests/experimentdata/test_io.py
@@ -241,3 +241,76 @@ def test_figure_load_png(tmp_path):
     loaded = plt.imread(str(png_path))
     assert isinstance(loaded, np.ndarray)
     assert loaded.ndim == 3
+
+
+# ======================= concurrent writer/reader (#273) =======================
+
+
+def _writer_loop(path_str: str, n_iters: int) -> None:
+    """Process target: rewrite a 1000-row DataFrame repeatedly."""
+    import pandas as pd
+
+    from f3dasm._src._io import pandas_store
+
+    df = pd.DataFrame({"a": range(1000), "b": range(1000)})
+    for _ in range(n_iters):
+        pandas_store(df, path_str)
+
+
+def _reader_loop(path_str: str, n_iters: int, errors: list) -> None:
+    """Process target: read the DataFrame repeatedly and record any error."""
+    import pandas as pd
+
+    from f3dasm._src._io import pandas_load
+
+    for _ in range(n_iters):
+        try:
+            df = pandas_load(path_str)
+            # Sanity check: should always observe a fully populated frame
+            if len(df) != 1000:
+                errors.append(f"short read: {len(df)} rows")
+        except pd.errors.EmptyDataError as exc:
+            errors.append(f"EmptyDataError: {exc}")
+        except FileNotFoundError:
+            # The reader can race with the very first write — tolerable.
+            pass
+
+
+def test_pandas_store_concurrent_no_empty_data_error(tmp_path):
+    """Concurrent writer + reader must never observe a half-written file.
+
+    Regression for issue #273: `pandas.DataFrame.to_csv(path)` previously
+    truncated the file before writing, so a reader hitting the file
+    between truncate and the body raised `pd.errors.EmptyDataError`. The
+    atomic temp+rename in `_io._atomic_write` should make that race
+    invisible to readers.
+    """
+    import multiprocessing as mp
+
+    path_str = str(tmp_path / "concurrent")
+
+    # Seed the file once so the reader has something to read at start.
+    from f3dasm._src._io import pandas_store
+
+    pandas_store(pd.DataFrame({"a": range(1000), "b": range(1000)}), path_str)
+
+    n_iters = 200
+    with mp.Manager() as manager:
+        errors = manager.list()
+        ctx = mp.get_context("spawn")
+        writer = ctx.Process(target=_writer_loop, args=(path_str, n_iters))
+        reader = ctx.Process(
+            target=_reader_loop,
+            args=(path_str, n_iters, errors),
+        )
+
+        writer.start()
+        reader.start()
+        writer.join(timeout=60)
+        reader.join(timeout=60)
+
+        assert not writer.is_alive(), "writer process hung"
+        assert not reader.is_alive(), "reader process hung"
+        assert list(errors) == [], (
+            f"concurrent reader observed half-written files: {list(errors)}"
+        )


### PR DESCRIPTION
## Summary
- Every store function in `_src/_io.py` (`pickle_store`, `numpy_store`, `pandas_store`, `xarray_dataset_store`, `xarray_dataarray_store`, `figure_store`) wrote straight to the target path. `pandas.DataFrame.to_csv` (and the equivalents on the other backends) truncate the file before streaming the body, so a reader calling `from_file()` mid-write lands on an empty file and raises `pd.errors.EmptyDataError`. The race shows up under the SLURM array-job pipeline added in #324 where many workers store while a driver reads.
- New `_atomic_write(target, write_fn)` helper: writes to a sibling `*.tmp` file, then calls `Path.replace(target)`. POSIX `rename` is atomic at the inode level, so readers always see either the previous full file or the new full file — never an empty one.
- Routes every store function through the helper. `np.save` needs the file-object form to avoid auto-suffix mangling that would otherwise turn `0.npy.tmp` into `0.npy.tmp.npy`; that case is wrapped explicitly.

## Test plan
- [x] `uv run pytest tests/experimentdata/ --no-cov` — 597 passed
- [x] New `test_pandas_store_concurrent_no_empty_data_error` runs a multiprocess writer + reader loop (200 iterations each) and asserts the reader never observes `EmptyDataError`
- [x] `uv run pre-commit run --files src/f3dasm/_src/_io.py tests/experimentdata/test_io.py` — clean

Fix #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)