### PR TITLE
fix: reseed legacy global RNGs per job in _run_sample

### DIFF
--- a/src/f3dasm/_src/datagenerator.py
+++ b/src/f3dasm/_src/datagenerator.py
@@ -7,6 +7,7 @@ This module contains the DataGenerator abstraction.
 from __future__ import annotations
 
 import logging
+import random
 
 # Standard
 import traceback
@@ -16,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 # Third-party
+import numpy as np
 from filelock import FileLock
 from pathos.helpers import mp
 
@@ -43,6 +45,37 @@ __status__ = "Alpha"
 logger = logging.getLogger("f3dasm")
 
 # =============================================================================
+
+
+def _reseed_for_job(job_number: int | None) -> None:
+    """Reseed the legacy global RNGs from ``job_number`` for the current job.
+
+    `pathos`/`multiprocessing` workers fork from the parent process, which
+    means NumPy's *global* default RNG state (and Python's ``random``
+    state) is inherited verbatim at fork time. Every worker then draws
+    the same numbers from ``np.random.*`` and ``random.*`` unless the
+    user explicitly creates a seeded `Generator` inside their function.
+
+    Derive a deterministic per-job seed via
+    ``np.random.SeedSequence(job_number)`` and seed both the NumPy
+    legacy global state and ``random`` with it before invoking the
+    user's `execute_fn`. The result is each parallel worker sees a
+    distinct random stream while runs remain reproducible given the
+    same job indices.
+
+    Skipped when ``job_number`` is None (no stable entropy source to
+    derive a seed from).
+
+    Parameters
+    ----------
+    job_number : int or None
+        The index of the job whose worker is about to run.
+    """
+    if job_number is None:
+        return
+    seed_int = int(np.random.SeedSequence(job_number).generate_state(1)[0])
+    np.random.seed(seed_int)
+    random.seed(seed_int)
 
 
 def _run_sample(
@@ -83,6 +116,7 @@ def _run_sample(
     """
     try:
         logger.debug(f"Running experiment_sample {job_number}")
+        _reseed_for_job(job_number)
         if pass_id and job_number is not None:
             experiment_sample = execute_fn(
                 experiment_sample=experiment_sample, id=job_number, **kwargs

--- a/tests/datageneration/test_parallel_seed.py
+++ b/tests/datageneration/test_parallel_seed.py
@@ -1,0 +1,110 @@
+"""Regression tests for issue #247: parallel workers must see different
+random numbers from `np.random.*` and `random.*`."""
+
+import random
+
+import numpy as np
+import pytest
+
+from f3dasm import ExperimentData, ExperimentSample, create_sampler
+from f3dasm._src.datagenerator import (
+    _reseed_for_job,
+    _run_sample,
+    evaluate_multiprocessing,
+    evaluate_sequential,
+)
+from f3dasm.design import Domain
+
+pytestmark = pytest.mark.smoke
+
+
+def _draw_globals_fn(experiment_sample: ExperimentSample, **kwargs):
+    """Record one draw from each legacy global RNG so a test can check
+    that parallel workers do not see identical sequences."""
+    experiment_sample.store(
+        "np_draw", float(np.random.random()), to_disk=False
+    )
+    experiment_sample.store("py_draw", random.random(), to_disk=False)
+    return experiment_sample
+
+
+@pytest.fixture
+def domain_with_outputs():
+    d = Domain()
+    d.add_float(name="x", low=0.0, high=1.0)
+    d.add_output(name="np_draw")
+    d.add_output(name="py_draw")
+    return d
+
+
+@pytest.fixture
+def four_sample_data(domain_with_outputs):
+    data = ExperimentData(domain=domain_with_outputs)
+    return create_sampler("random", seed=42).call(data=data, n_samples=4)
+
+
+class TestReseedForJob:
+    def test_distinct_seeds_yield_distinct_draws(self):
+        seen = set()
+        for job_number in range(8):
+            _reseed_for_job(job_number)
+            seen.add((float(np.random.random()), random.random()))
+        # All eight (np, py) pairs must differ — that's the property the
+        # parallel workers rely on.
+        assert len(seen) == 8
+
+    def test_same_seed_is_reproducible(self):
+        _reseed_for_job(5)
+        a_np, a_py = float(np.random.random()), random.random()
+        _reseed_for_job(5)
+        b_np, b_py = float(np.random.random()), random.random()
+        assert a_np == b_np
+        assert a_py == b_py
+
+    def test_none_job_number_is_a_noop(self):
+        # When no stable entropy source is known we should leave the
+        # global RNG state untouched. Lock current state, call helper,
+        # confirm the next draw matches what we'd have gotten anyway.
+        np.random.seed(123)
+        random.seed(123)
+        expected_np = float(np.random.random())
+        expected_py = random.random()
+
+        np.random.seed(123)
+        random.seed(123)
+        _reseed_for_job(None)
+        assert float(np.random.random()) == expected_np
+        assert random.random() == expected_py
+
+
+def test_evaluate_sequential_workers_see_distinct_random(
+    four_sample_data,
+):
+    """Sequential mode reseeds each sample from its job_number, so the
+    four samples must record four different np_draw/py_draw values."""
+    result = evaluate_sequential(
+        execute_fn=_draw_globals_fn, data=four_sample_data, pass_id=False
+    )
+    _, df = result.to_pandas()
+    assert df["np_draw"].nunique() == len(df)
+    assert df["py_draw"].nunique() == len(df)
+
+
+def test_evaluate_multiprocessing_workers_see_distinct_random(
+    four_sample_data,
+):
+    """Parallel workers fork from the parent's RNG state. Without the
+    per-job reseed every worker would record the same np_draw."""
+    result = evaluate_multiprocessing(
+        execute_fn=_draw_globals_fn,
+        data=four_sample_data,
+        pass_id=False,
+        nodes=4,
+    )
+    _, df = result.to_pandas()
+    assert df["np_draw"].nunique() == len(df), (
+        f"expected 4 distinct np draws, got {df['np_draw'].tolist()}"
+    )
+    assert df["py_draw"].nunique() == len(df), (
+        f"expected 4 distinct py draws, got {df['py_draw'].tolist()}"
+    )


### PR DESCRIPTION
## Summary
- `pathos`/`multiprocessing` workers fork from the parent process, so NumPy's global default RNG state and Python's `random` state are inherited verbatim. Every parallel worker therefore drew the same numbers from `np.random.*` and `random.*` — exactly what the original issue reported.
- New `_reseed_for_job(job_number)` derives a deterministic per-job seed via `np.random.SeedSequence(job_number)` and seeds both NumPy's legacy global state and Python's `random` with it. `_run_sample` calls it right before invoking the user's `execute_fn`. No-op when `job_number is None`.
- Each parallel worker now sees a distinct random stream and re-runs are reproducible given the same job indices.

## Test plan
- [x] `uv run pytest tests/datageneration/ --no-cov` — 84 passed
- [x] New `tests/datageneration/test_parallel_seed.py`:
  - `_reseed_for_job` distinctness, reproducibility, and the None no-op contract
  - End-to-end check on `evaluate_sequential` and `evaluate_multiprocessing` that all four workers record different `np.random.random()` and `random.random()` draws
- [x] `uv run pre-commit run --files src/f3dasm/_src/datagenerator.py tests/datageneration/test_parallel_seed.py` — clean

## Notes for reviewers
- This is one of the three branches that touches `datagenerator.py` (#247 → #234 → #309 per the plan). The other two will be opened off `develop` as well and will need a rebase once this lands.

Fix #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)