### PR TITLE
fix: validate decorated DataGenerator signature against Domain

### DIFF
--- a/src/f3dasm/_src/core.py
+++ b/src/f3dasm/_src/core.py
@@ -412,9 +412,12 @@ def datagenerator(
     """
     Decorator to convert a function into a `DataGenerator` subclass.
 
-    The decorated function should take named arguments matching the keys in
-    the Domain and return one or multiple output values. These values will be
-    stored in the `ExperimentData` under the names specified in `output_names`.
+    The decorated function's parameter names must match either an input
+    parameter name in the Domain or an explicit kwarg later passed to
+    `call(...)`; defaulted parameters are optional. A mismatch is caught
+    at `arm`/`call` time with a clear ``ValueError`` (see issue #268).
+    The function's return values will be stored in the `ExperimentSample`
+    object under the names specified in `output_names`.
 
     Parameters
     ----------
@@ -468,6 +471,68 @@ def datagenerator(
             """
             Auto-generated DataGenerator subclass from a decorated function.
             """
+
+            def _validate_signature(
+                self,
+                data: ExperimentData,
+                supplied_kwargs: Iterable[str],
+            ) -> None:
+                """Check ``f``'s required args resolve to a known source.
+
+                A decorated data generator pulls each required argument
+                of ``f`` from one of three places at execute time: the
+                Domain's input parameters, an explicit kwarg on
+                ``DataGenerator.call``, or (if defined) a parameter
+                default. When none of those covers a required arg, the
+                user previously got the confusing ``TypeError: cannot
+                unpack non-iterable NoneType object`` from inside
+                ``_run_sample``. Catch the mismatch eagerly instead with
+                a message that names the offending arguments and lists
+                what's available (see issue #268).
+                """
+                required = {
+                    name
+                    for name, p in signature.parameters.items()
+                    if p.default is inspect.Parameter.empty
+                    and p.kind
+                    not in (
+                        inspect.Parameter.VAR_POSITIONAL,
+                        inspect.Parameter.VAR_KEYWORD,
+                    )
+                }
+                domain_inputs = set(data.domain.input_names)
+                missing = required - domain_inputs - set(supplied_kwargs)
+                if missing:
+                    raise ValueError(
+                        f"DataGenerator function `{f.__name__}` declares "
+                        f"required argument(s) {sorted(missing)} that "
+                        "are not present in the Domain and were not "
+                        f"supplied via `call(...)` kwargs. Domain "
+                        f"inputs are {sorted(domain_inputs)}. Rename "
+                        "your function arguments to match the Domain "
+                        "parameter names, give them default values, or "
+                        "pass them explicitly to `call(...)`."
+                    )
+
+            def arm(self, data: ExperimentData) -> None:
+                """Validate that ``f``'s required args match the Domain.
+
+                Equivalent to the validation that ``call`` runs, but
+                without knowledge of any kwargs the user will pass
+                later. Use this when you want the mismatch to surface
+                eagerly during pipeline setup.
+                """
+                self._validate_signature(data, supplied_kwargs=())
+
+            def call(
+                self, data: ExperimentData, **kwargs: Any
+            ) -> ExperimentData:
+                # `DataGenerator.call` does not auto-invoke `arm`, so we
+                # run the signature check here -- with the user's
+                # kwargs in scope -- as a safety net for the common
+                # `dg.call(data=ed, ...)` pattern (issue #268).
+                self._validate_signature(data, supplied_kwargs=kwargs.keys())
+                return super().call(data=data, **kwargs)
 
             def execute(
                 self, experiment_sample: ExperimentSample, **kwargs: Any

--- a/tests/datageneration/test_datagenerator.py
+++ b/tests/datageneration/test_datagenerator.py
@@ -64,3 +64,61 @@ def test_invalid_parallelization_mode():
 
     with pytest.raises(ValueError):
         experiment_data = func.call(data=experiment_data, mode="invalid")
+
+
+# ====== signature validation (#268) =========================================
+
+
+def test_decorated_function_with_mismatched_arg_raises_on_call():
+    """User function declares `seed`, Domain provides `x`/`z` -- arm must
+    raise immediately rather than letting `_run_sample` fail with the
+    confusing `cannot unpack non-iterable NoneType object` error.
+
+    This is the second repro from issue #268 (renamed argument).
+    """
+    domain = Domain()
+    domain.add_float("x", low=0.0, high=100.0)
+    domain.add_float("z", low=0.0, high=100.0)
+    domain.add_output("y")
+
+    @datagenerator(output_names="y")
+    def fn(seed):
+        return seed
+
+    ed = ExperimentData(domain=domain, input_data=[{"x": 1.0, "z": 2.0}])
+    with pytest.raises(ValueError, match=r"required argument\(s\) \['seed'\]"):
+        fn.call(data=ed)
+
+
+def test_decorated_function_with_extra_domain_arg_passes():
+    """Domain may legitimately carry parameters the function doesn't
+    consume (e.g. metadata kept for downstream blocks). The validation
+    should only flag function args that have no Domain backing."""
+    domain = Domain()
+    domain.add_float("x", low=0.0, high=100.0)
+    domain.add_float("z", low=0.0, high=100.0)
+    domain.add_output("y")
+
+    @datagenerator(output_names="y")
+    def fn(x):
+        return x * 2
+
+    ed = ExperimentData(domain=domain, input_data=[{"x": 1.0, "z": 2.0}])
+    # Should not raise.
+    fn.arm(data=ed)
+
+
+def test_decorated_function_with_defaulted_arg_passes():
+    """Arguments with defaults are optional, so a missing Domain entry
+    for them must not trigger the validation."""
+    domain = Domain()
+    domain.add_float("x", low=0.0, high=1.0)
+    domain.add_output("y")
+
+    @datagenerator(output_names="y")
+    def fn(x, multiplier=2.0):
+        return x * multiplier
+
+    ed = ExperimentData(domain=domain, input_data=[{"x": 1.0}])
+    fn.arm(data=ed)  # no raise
+    fn.call(data=ed)  # no raise either


### PR DESCRIPTION
## Summary
- When a function decorated with `@datagenerator` declared a required argument that did not appear in the Domain's input parameters (and was not passed via a `call(...)` kwarg), the mismatch surfaced from inside `_run_sample` as the confusing `TypeError: cannot unpack non-iterable NoneType object`.
- Make the contract explicit: `FunctionDataGenerator` gains a `_validate_signature` helper invoked from both `arm` and `call`. It raises `ValueError` when any required parameter of `f` is missing from `data.domain.input_names` *and* the kwargs the user passed to `call(...)`. The error message names the offending arguments and lists the Domain inputs that are available.
- Update the decorator docstring to describe the parameter-name contract.

## Test plan
- [x] `uv run pytest tests/datageneration/ --no-cov` — 82 passed
- [x] Three new tests cover (a) the renamed-argument repro from the issue body, (b) the Domain-may-carry-extra-args path, (c) the defaulted-argument path
- [x] Original repro from the issue body now raises with `Domain inputs are ['x', 'z']. Rename your function arguments to match the Domain parameter names, give them default values, or pass them explicitly to call(...).`
- [x] `uv run mkdocs build` — clean
- [x] `uv run pre-commit run --files src/f3dasm/_src/core.py tests/datageneration/test_datagenerator.py` — clean

Fix #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)