### PR TITLE
feat: forward load_kwargs through to the LoadFunction

### DIFF
--- a/src/f3dasm/_src/_io.py
+++ b/src/f3dasm/_src/_io.py
@@ -428,6 +428,7 @@ def load_object(
     project_dir: Path,
     path: str | Path,
     load_function: Optional[Callable] = None,
+    **load_kwargs: Any,
 ) -> Any:
     """
     Load an object from disk from a given path and storing method.
@@ -440,6 +441,11 @@ def load_object(
         The path to the object.
     load_function : Optional[Callable], optional
         The method to load the object, by default None.
+    **load_kwargs : Any
+        Auxiliary keyword arguments forwarded to ``load_function`` --
+        see ``Parameter(load_kwargs=...)`` and issue #285. The built-in
+        loaders ignore unknown kwargs; a fallback ``pickle_load`` will
+        also receive them.
 
     Returns
     -------
@@ -475,6 +481,8 @@ def load_object(
             load_function = LOAD_FUNCTION_MAPPING[suffix]
 
     # Store the object and return the storage location
+    if load_kwargs:
+        return load_function(_path, **load_kwargs)
     return load_function(_path)
 
 
@@ -552,12 +560,17 @@ class ReferenceValue:
     ----------
     reference : Path
         Path to the stored object, relative to the experiment data subfolder.
-    load_function : Callable[[Path], Any]
-        Callable that accepts the absolute path and returns the loaded object.
+    load_function : Callable[..., Any]
+        Callable that accepts the absolute path (and any
+        ``load_kwargs``) and returns the loaded object.
+    load_kwargs : dict[str, Any], optional
+        Extra keyword arguments forwarded to ``load_function`` on every
+        :meth:`load` call (issue #285). Defaults to None.
     """
 
     reference: Path
-    load_function: Callable[[Path], Any]
+    load_function: Callable[..., Any]
+    load_kwargs: Optional[dict[str, Any]] = None
 
     def load(self, project_dir: Path) -> Any:
         """Load and return the referenced object from disk.
@@ -576,6 +589,7 @@ class ReferenceValue:
             project_dir=project_dir,
             path=self.reference,
             load_function=self.load_function,
+            **(self.load_kwargs or {}),
         )
 
     def copy_to(
@@ -600,7 +614,9 @@ class ReferenceValue:
             self.reference, old_project_dir, new_project_dir
         )
         return ReferenceValue(
-            reference=Path(new_reference), load_function=self.load_function
+            reference=Path(new_reference),
+            load_function=self.load_function,
+            load_kwargs=self.load_kwargs,
         )
 
     def __hash__(self) -> int:
@@ -615,13 +631,18 @@ class ReferenceValue:
         Returns
         -------
         dict
-            A dict with ``__type__``, ``reference``, and a hex-encoded
-            pickle of ``load_function``.
+            A dict with ``__type__``, ``reference``, and hex-encoded
+            pickles of ``load_function`` and ``load_kwargs`` (if set).
         """
         return {
             "__type__": "ReferenceValue",
             "reference": str(self.reference),
             "load_function": pickle.dumps(self.load_function).hex(),
+            "load_kwargs": (
+                pickle.dumps(self.load_kwargs).hex()
+                if self.load_kwargs is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -638,9 +659,13 @@ class ReferenceValue:
         ReferenceValue
             The reconstructed instance.
         """
+        load_kwargs = None
+        if data.get("load_kwargs"):
+            load_kwargs = pickle.loads(bytes.fromhex(data["load_kwargs"]))
         return cls(
             reference=Path(data["reference"]),
             load_function=pickle.loads(bytes.fromhex(data["load_function"])),
+            load_kwargs=load_kwargs,
         )
 
 
@@ -661,14 +686,19 @@ class ToDiskValue:
         Parameter name used to construct the storage path.
     store_function : Callable[[Any, Path], Path]
         Callable that writes `object` to disk and returns the path.
-    load_function : Callable[[Path], Any]
+    load_function : Callable[..., Any]
         Callable that reads and returns the object from disk.
+    load_kwargs : dict[str, Any], optional
+        Extra keyword arguments forwarded to ``load_function`` when the
+        resulting :class:`ReferenceValue` is later loaded (issue #285).
+        Defaults to None.
     """
 
     object: Any
     name: str
     store_function: Callable[[Any, Path], Path]
-    load_function: Callable[[Path], Any]
+    load_function: Callable[..., Any]
+    load_kwargs: Optional[dict[str, Any]] = None
 
     def store(self, project_dir: Path, idx: int) -> Path:
         """Write the object to disk and return the stored path.
@@ -717,4 +747,5 @@ class ToDiskValue:
         return ReferenceValue(
             reference=reference,
             load_function=self.load_function,
+            load_kwargs=self.load_kwargs,
         )

--- a/src/f3dasm/_src/core.py
+++ b/src/f3dasm/_src/core.py
@@ -523,6 +523,7 @@ def datagenerator(
                             to_disk=parameter.to_disk,
                             store_function=parameter.store_function,
                             load_function=parameter.load_function,
+                            load_kwargs=parameter.load_kwargs,
                         )
                     else:
                         experiment_sample.store(name=name, object=value)

--- a/src/f3dasm/_src/design/domain.py
+++ b/src/f3dasm/_src/design/domain.py
@@ -399,6 +399,7 @@ class Domain:
         to_disk=False,
         store_function: Optional[StoreFunction] = None,
         load_function: Optional[LoadFunction] = None,
+        load_kwargs: Optional[dict[str, Any]] = None,
     ):
         """Add a new parameter to the domain.
 
@@ -412,6 +413,12 @@ class Domain:
             Function to store the parameter, by default None.
         load_function : LoadFunction, optional
             Function to load the parameter, by default None.
+        load_kwargs : dict[str, Any], optional
+            Extra keyword arguments forwarded to `load_function` each
+            time the stored object is loaded. Useful when the
+            deserialiser needs auxiliary state (e.g. an `equinox`
+            template via ``load_kwargs={"like": template}``). Defaults
+            to None.
 
         Examples
         -------
@@ -426,6 +433,7 @@ class Domain:
             Parameter(
                 store_function=store_function,
                 load_function=load_function,
+                load_kwargs=load_kwargs,
                 to_disk=to_disk,
             ),
         )
@@ -623,6 +631,7 @@ class Domain:
         exist_ok: bool = False,
         store_function: Optional[StoreFunction] = None,
         load_function: Optional[LoadFunction] = None,
+        load_kwargs: Optional[dict[str, Any]] = None,
     ):
         """Add a new output parameter to the domain.
 
@@ -640,6 +649,9 @@ class Domain:
             Function to store the parameter, by default None.
         load_function : LoadFunction, optional
             Function to load the parameter, by default None.
+        load_kwargs : dict[str, Any], optional
+            Extra keyword arguments forwarded to `load_function` each
+            time the stored object is loaded. Defaults to None.
 
         Examples
         -------
@@ -660,6 +672,7 @@ class Domain:
             to_disk=to_disk,
             store_function=store_function,
             load_function=load_function,
+            load_kwargs=load_kwargs,
         )
 
     #                                                                   Getters

--- a/src/f3dasm/_src/design/parameter.py
+++ b/src/f3dasm/_src/design/parameter.py
@@ -54,7 +54,7 @@ class StoreFunction(Protocol):
 class LoadFunction(Protocol):
     """Base class for storing and loading output data from disk"""
 
-    def __call__(path: str) -> Any:
+    def __call__(path: str, **kwargs: Any) -> Any:
         """
         Protocol class for loading output data from disk.
 
@@ -62,6 +62,14 @@ class LoadFunction(Protocol):
         ----------
         path : str
             The location to load the object from.
+        **kwargs : Any
+            Auxiliary state required by the load implementation. f3dasm
+            forwards any ``load_kwargs`` registered on the matching
+            :class:`Parameter` (see issue #285). The built-in loaders
+            ignore unknown kwargs, so custom deserialisers can request
+            extra state (e.g. an ``equinox`` template via
+            ``load_kwargs={"like": template}``) without breaking the
+            default path.
 
         Returns
         -------
@@ -84,6 +92,7 @@ class Parameter:
         to_disk: bool = False,
         store_function: Optional[StoreFunction] = None,
         load_function: Optional[LoadFunction] = None,
+        load_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Initialize the Parameter.
@@ -96,12 +105,18 @@ class Parameter:
             Function to store the parameter to disk. Defaults to None.
         load_function : Optional[LoadFunction], optional
             Function to load the parameter from disk. Defaults to None.
+        load_kwargs : dict[str, Any], optional
+            Extra keyword arguments forwarded to ``load_function`` each
+            time the stored object is loaded. Useful when the
+            deserialiser needs auxiliary state (an ``equinox`` template,
+            a torch module skeleton for a `state_dict`, etc.) -- see
+            issue #285. Defaults to None (no kwargs forwarded).
 
         Raises
         ------
         ValueError
-            If `to_disk` is False but either `store_function` or
-            `load_function` is not None.
+            If `to_disk` is False but either `store_function`,
+            `load_function`, or `load_kwargs` is not None.
 
         Notes
         -----
@@ -121,16 +136,19 @@ class Parameter:
         """
 
         if not to_disk and (
-            store_function is not None or load_function is not None
+            store_function is not None
+            or load_function is not None
+            or load_kwargs is not None
         ):
             raise ValueError(
-                "If 'to_disk' is False, 'store_function' and"
-                "load_function' must be None."
+                "If 'to_disk' is False, 'store_function', "
+                "'load_function', and 'load_kwargs' must be None."
             )
 
         self.to_disk = to_disk
         self.store_function = store_function
         self.load_function = load_function
+        self.load_kwargs = load_kwargs
 
     def __str__(self):
         """Return a string representation of the Parameter.
@@ -208,6 +226,7 @@ class Parameter:
             to_disk=self.to_disk,
             store_function=self.store_function,
             load_function=self.load_function,
+            load_kwargs=self.load_kwargs,
         )
 
     def to_dict(self) -> dict:
@@ -244,6 +263,11 @@ class Parameter:
                 if self.load_function
                 else None
             ),
+            "load_kwargs": (
+                pickle.dumps(self.load_kwargs).hex()
+                if self.load_kwargs is not None
+                else None
+            ),
         }
         if dataclasses.is_dataclass(self):
             for f in dataclasses.fields(self):
@@ -274,6 +298,7 @@ class Parameter:
         param_type = param_dict["type"]
         store_function = None
         load_function = None
+        load_kwargs = None
         if param_dict.get("store_function"):
             store_function = pickle.loads(
                 bytes.fromhex(param_dict["store_function"])
@@ -282,12 +307,17 @@ class Parameter:
             load_function = pickle.loads(
                 bytes.fromhex(param_dict["load_function"])
             )
+        if param_dict.get("load_kwargs"):
+            load_kwargs = pickle.loads(
+                bytes.fromhex(param_dict["load_kwargs"])
+            )
 
         if param_type == "object":
             return Parameter(
                 to_disk=param_dict["to_disk"],
                 store_function=store_function,
                 load_function=load_function,
+                load_kwargs=load_kwargs,
             )
 
         param_cls = _PARAM_REGISTRY.get(param_type)

--- a/src/f3dasm/_src/experimentdata.py
+++ b/src/f3dasm/_src/experimentdata.py
@@ -1964,6 +1964,7 @@ def _store(
                     to_disk=True,
                     store_function=value.store_function,
                     load_function=value.load_function,
+                    load_kwargs=value.load_kwargs,
                 )
             # Store the value on disk
             reference = value.store(
@@ -1988,6 +1989,7 @@ def _store(
                     to_disk=True,
                     store_function=value.store_function,
                     load_function=value.load_function,
+                    load_kwargs=value.load_kwargs,
                 )
             # Store the value on disk
             reference = value.store(

--- a/src/f3dasm/_src/experimentsample.py
+++ b/src/f3dasm/_src/experimentsample.py
@@ -505,6 +505,7 @@ class ExperimentSample:
         to_disk: bool = False,
         store_function: Callable | None = None,
         load_function: Callable | None = None,
+        load_kwargs: dict | None = None,
         which: Literal["input", "output"] = "output",
     ):
         """
@@ -524,6 +525,10 @@ class ExperimentSample:
         load_function : Optional[Type[Callable]], optional
             The function to use for loading the object from disk,
             by default None.
+        load_kwargs : dict, optional
+            Extra keyword arguments forwarded to ``load_function`` when
+            the stored object is later loaded (issue #285). Defaults to
+            None.
         which : Literal['input', 'output'], optional
             Specify whether to store the object in input or output data,
             by default 'output'.
@@ -549,7 +554,7 @@ class ExperimentSample:
 
         .. code-block:: python
 
-            def load_function(path: str) -> Any:
+            def load_function(path: str, **kwargs: Any) -> Any:
                 ...
         """
         value = (
@@ -560,6 +565,7 @@ class ExperimentSample:
                 name=name,
                 store_function=store_function,
                 load_function=load_function,
+                load_kwargs=load_kwargs,
             )
         )
 

--- a/tests/design/test_custom_store_load.py
+++ b/tests/design/test_custom_store_load.py
@@ -1,0 +1,155 @@
+"""Regression tests for issue #285: LoadFunction must accept **kwargs and
+the ``load_kwargs`` registered on the Parameter must be forwarded on every
+load.
+
+The flagship use case is loaders like ``equinox.tree_deserialise_leaves``
+that need a template (`like=template`) to reconstruct the object."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from f3dasm import ExperimentData, ExperimentSample
+from f3dasm._src._io import (
+    ReferenceValue,
+    ToDiskValue,
+    load_object,
+    pickle_load,
+)
+from f3dasm._src.design.parameter import Parameter
+from f3dasm.design import Domain
+
+pytestmark = pytest.mark.smoke
+
+
+class Skeleton:
+    """Stand-in for an `equinox.Module` template used to drive
+    deserialisation. Holds the schema the loader needs to reconstruct
+    the object."""
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+
+
+def _store_pair(obj: dict, path: str) -> str:
+    """Write ``obj`` as a `.pkl` file alongside the chosen extension."""
+    import pickle as _pickle
+
+    _path = Path(path).with_suffix(".pkl")
+    with open(_path, "wb") as f:
+        _pickle.dump(obj, f)
+    return str(_path)
+
+
+def _load_pair(path: str, *, like: Skeleton) -> dict:
+    """Load and attach the skeleton key to the deserialised payload.
+
+    Models the equinox case: the loader receives auxiliary state via
+    kwargs that is required to interpret the bytes on disk."""
+    payload = pickle_load(path)
+    return {"payload": payload, "schema_key": like.key}
+
+
+def test_load_kwargs_forwarded_through_reference_value(tmp_path):
+    """`ReferenceValue.load` must forward the registered `load_kwargs`
+    to the load function. Without this plumbing the user would have to
+    bake `like=...` into a closure and lose the JSON-roundtrip ability
+    that f3dasm relies on for `Domain.from_file`."""
+    skeleton = Skeleton(key="version-1")
+    obj = ToDiskValue(
+        object={"value": 42},
+        name="custom",
+        store_function=_store_pair,
+        load_function=_load_pair,
+        load_kwargs={"like": skeleton},
+    )
+    # Set up an experiment-data subfolder so `load_object` resolves paths
+    # the same way it does in production.
+    project_dir = tmp_path
+    (project_dir / "experiment_data").mkdir(parents=True, exist_ok=True)
+    reference_path = Path(obj.store(project_dir=project_dir, idx=0))
+
+    ref = obj.to_reference(reference=reference_path)
+    loaded = ref.load(project_dir=project_dir)
+    assert loaded == {"payload": {"value": 42}, "schema_key": "version-1"}
+
+
+def test_parameter_rejects_load_kwargs_when_not_to_disk():
+    """Setting `load_kwargs` only makes sense when the parameter is
+    `to_disk=True`. Mismatch should raise the same way as
+    `load_function`."""
+    with pytest.raises(ValueError, match="load_kwargs"):
+        Parameter(to_disk=False, load_kwargs={"like": object()})
+
+
+def test_parameter_copy_preserves_load_kwargs():
+    """`_copy()` carries `load_kwargs` so domain copies do not silently
+    drop the deserialisation hint."""
+    skeleton = Skeleton(key="version-2")
+    param = Parameter(
+        to_disk=True,
+        store_function=lambda obj, p: p,
+        load_function=lambda p, **kw: kw,
+        load_kwargs={"like": skeleton},
+    )
+    copy = param._copy()
+    assert copy.load_kwargs == {"like": skeleton}
+
+
+def test_load_object_ignores_kwargs_for_builtin_loaders(tmp_path):
+    """The default loaders take only `path` -- if no `load_kwargs` are
+    registered we must keep calling them with a single positional
+    argument so the existing built-ins keep working."""
+    import numpy as np
+
+    project_dir = tmp_path
+    (project_dir / "experiment_data").mkdir(parents=True, exist_ok=True)
+    rel_path = Path("test/0.npy")
+    full = project_dir / "experiment_data" / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    np.save(full, np.array([1, 2, 3]))
+
+    loaded = load_object(project_dir=project_dir, path=rel_path)
+    np.testing.assert_array_equal(loaded, np.array([1, 2, 3]))
+
+
+def test_load_kwargs_end_to_end_through_experiment_data(tmp_path):
+    """End-to-end: domain output declared with `load_kwargs`, sample
+    stored, then loaded back -- the auxiliary state must reach the
+    custom loader."""
+    skeleton = Skeleton(key="version-3")
+    domain = Domain()
+    domain.add_float(name="x", low=0.0, high=1.0)
+    domain.add_output(
+        name="custom",
+        to_disk=True,
+        store_function=_store_pair,
+        load_function=_load_pair,
+        load_kwargs={"like": skeleton},
+    )
+
+    ed = ExperimentData(domain=domain, input_data=[{"x": 0.5}])
+    # Use the property setter (not `set_project_dir(..., in_place=True)`)
+    # so each ExperimentSample's `project_dir` is propagated -- _store
+    # uses `experiment_sample.project_dir` for the on-disk location.
+    ed.project_dir = tmp_path
+
+    sample = ed.data[0]
+    sample.store(
+        name="custom",
+        object={"value": 7},
+        to_disk=True,
+        store_function=_store_pair,
+        load_function=_load_pair,
+        load_kwargs={"like": skeleton},
+    )
+    from f3dasm._src.experimentdata import _store as _store_helper
+
+    sample, domain = _store_helper(
+        experiment_sample=sample, idx=0, domain=ed.domain
+    )
+
+    assert isinstance(sample._output_data["custom"], ReferenceValue)
+    loaded = sample._output_data["custom"].load(project_dir=tmp_path)
+    assert loaded == {"payload": {"value": 7}, "schema_key": "version-3"}


### PR DESCRIPTION
## Summary
Closes #285. The `LoadFunction` Protocol previously accepted only `path`, so deserialisers that need auxiliary state — the canonical example is `equinox.tree_deserialise_leaves(path, like=template)` — had no way to receive that state through f3dasm's store/load plumbing.

- Extend `LoadFunction.__call__` to `(path: str, **kwargs: Any) -> Any`. Built-in loaders take only `path` and are still invoked positionally when no kwargs are registered, so they keep working unchanged.
- New `load_kwargs: dict[str, Any] | None` field on `Parameter` (with `to_dict` / `from_dict` / `_copy` plumbing). Exposed on `Domain.add_parameter` and `Domain.add_output`.
- Carry the dict through `ToDiskValue` → `ReferenceValue` → `load_object`. `ReferenceValue.load()` unpacks it into the load call when present; the built-in loaders are still called with just `path` when no kwargs are registered.
- `ExperimentSample.store(...)` accepts `load_kwargs=`, and the auto-generated `FunctionDataGenerator` forwards `parameter.load_kwargs` when storing outputs.
- `experimentdata._store` carries `load_kwargs` when it auto-registers a parameter from an in-flight `ToDiskValue`.

## Test plan
- [x] New `tests/design/test_custom_store_load.py` (5 cases): reference-value forwards kwargs, `Parameter(to_disk=False, load_kwargs=...)` raises, `_copy` preserves it, built-in loaders still work without kwargs, end-to-end domain → store → load.
- [x] `uv run pytest tests/design/ tests/experimentdata/ tests/datageneration/ --no-cov` — 792 passed.
- [x] `uv run pre-commit run --files ...` — clean.

## Notes for reviewers
- The Protocol change is additive — existing loaders that take only `path` keep working because `load_object` only injects kwargs when `load_kwargs` is non-empty.
- `Parameter.__init__` now raises if `load_kwargs` is supplied while `to_disk=False`, mirroring the existing rule for `store_function`/`load_function`.

Fix #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)