### PR TITLE
feat: optional tqdm progress bar in evaluate + driver summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ version = "2.2.3"
 [project.optional-dependencies]
 all = [
   "abaqus2py>=1.0.0",
-  "optuna>=4.4.0"
+  "optuna>=4.4.0",
+  "tqdm>=4.66.0"
 ]
 dev = [
   "pre-commit>=4.4.0",
@@ -56,6 +57,9 @@ docs = [
   "mkdocstrings>=0.30.1",
   "mkdocstrings-python>=1.18.2",
   "pymdown-extensions>=10.16.1"
+]
+progress = [
+  "tqdm>=4.66.0"
 ]
 tests = [
   "hypothesis>=6.138.0",

--- a/src/f3dasm/_src/datagenerator.py
+++ b/src/f3dasm/_src/datagenerator.py
@@ -10,7 +10,8 @@ import logging
 
 # Standard
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,74 @@ __status__ = "Alpha"
 logger = logging.getLogger("f3dasm")
 
 # =============================================================================
+
+
+@contextmanager
+def _progress_bar(
+    total: int | None, enabled: bool, desc: str
+) -> Iterator[Callable[[int], None]]:
+    """Yield a callback that advances a tqdm bar -- or a no-op if tqdm is
+    unavailable or progress reporting was not requested (issue #234).
+
+    Parameters
+    ----------
+    total : int or None
+        Expected number of work items, when known.
+    enabled : bool
+        Whether the user asked for a progress bar.
+    desc : str
+        Label shown next to the bar.
+
+    Yields
+    ------
+    Callable[[int], None]
+        ``update(n)``: advance the bar by ``n`` units. A no-op when
+        progress is disabled or tqdm is missing.
+    """
+    if not enabled:
+        yield lambda _n=1: None
+        return
+
+    try:
+        from tqdm.auto import tqdm  # type: ignore[import-not-found]
+    except ImportError:
+        logger.warning(
+            "`progress=True` requested but `tqdm` is not installed; "
+            "running silently. Install `f3dasm[progress]` to enable "
+            "progress bars."
+        )
+        yield lambda _n=1: None
+        return
+
+    bar = tqdm(total=total, desc=desc, leave=False)
+    try:
+        yield bar.update
+    finally:
+        bar.close()
+
+
+def _progress_iter(
+    iterable: Iterable[Any],
+    *,
+    total: int | None,
+    enabled: bool,
+    desc: str,
+) -> Iterable[Any]:
+    """Wrap ``iterable`` in tqdm when ``enabled`` is True and tqdm is
+    available; otherwise return it unchanged. See :func:`_progress_bar`
+    for the rationale (issue #234)."""
+    if not enabled:
+        return iterable
+    try:
+        from tqdm.auto import tqdm  # type: ignore[import-not-found]
+    except ImportError:
+        logger.warning(
+            "`progress=True` requested but `tqdm` is not installed; "
+            "running silently. Install `f3dasm[progress]` to enable "
+            "progress bars."
+        )
+        return iterable
+    return tqdm(iterable, total=total, desc=desc, leave=False)
 
 
 def _run_sample(
@@ -113,6 +182,7 @@ def evaluate_sequential(
     execute_fn: Callable[..., ExperimentSample],
     data: ExperimentData,
     pass_id: bool,
+    progress: bool = False,
     **kwargs,
 ) -> ExperimentData:
     """Run the operation sequentially
@@ -125,6 +195,11 @@ def evaluate_sequential(
         The ExperimentData object containing the samples to be processed
     pass_id : bool
         Whether to pass the job index to the execute function
+    progress : bool, optional
+        If True, display a tqdm progress bar over the open jobs.
+        Requires the optional `tqdm` dependency; if missing, the
+        evaluator falls back to silent execution with a warning
+        (issue #234). Defaults to False.
     kwargs : dict
         Any keyword arguments that need to be supplied to the function
 
@@ -133,24 +208,28 @@ def evaluate_sequential(
     ExperimentData
         The updated ExperimentData object
     """
+    total = len(data.select_with_status("open"))
+    with _progress_bar(
+        total=total, enabled=progress, desc="evaluate"
+    ) as update:
+        while True:
+            job_number, experiment_sample, domain = data.get_open_job()
+            if job_number is None:
+                logger.debug("No open jobs left!")
+                break
 
-    while True:
-        job_number, experiment_sample, domain = data.get_open_job()
-        if job_number is None:
-            logger.debug("No open jobs left!")
-            break
+            experiment_sample, domain = _run_sample(
+                execute_fn=execute_fn,
+                experiment_sample=experiment_sample,
+                domain=domain,
+                job_number=job_number,
+                pass_id=pass_id,
+                **kwargs,
+            )
 
-        experiment_sample, domain = _run_sample(
-            execute_fn=execute_fn,
-            experiment_sample=experiment_sample,
-            domain=domain,
-            job_number=job_number,
-            pass_id=pass_id,
-            **kwargs,
-        )
-
-        data.domain = domain
-        data.data[job_number] = experiment_sample
+            data.domain = domain
+            data.data[job_number] = experiment_sample
+            update(1)
 
     return data
 
@@ -160,6 +239,7 @@ def evaluate_multiprocessing(
     data: ExperimentData,
     pass_id: bool,
     nodes: int = mp.cpu_count(),
+    progress: bool = False,
     **kwargs,
 ) -> ExperimentData:
     """Run the operation using multiprocessing
@@ -174,6 +254,10 @@ def evaluate_multiprocessing(
         Whether to pass the job index to the execute function
     nodes : int, optional
         The number of parallel processes to use, by default mp.cpu_count()
+    progress : bool, optional
+        If True, display a tqdm progress bar over the open jobs as
+        each worker completes. Requires the optional `tqdm` dependency
+        (issue #234). Defaults to False.
     kwargs : dict
         Any keyword arguments that need to be supplied to the function
 
@@ -209,9 +293,16 @@ def evaluate_multiprocessing(
 
     if work_items:
         with mp.Pool(nodes) as pool:
-            # maybe implement pool.starmap_async ?
-            results: list[tuple[int, ExperimentSample, Domain]] = pool.map(
-                _worker, work_items
+            # `imap_unordered` lets tqdm tick as each worker finishes;
+            # ordering is restored on assignment via `job_number`.
+            result_iter = pool.imap_unordered(_worker, work_items)
+            results = list(
+                _progress_iter(
+                    result_iter,
+                    total=len(work_items),
+                    enabled=progress,
+                    desc="evaluate",
+                )
             )
 
         for job_number, experiment_sample, domain in results:
@@ -231,6 +322,7 @@ def evaluate_cluster(
     pass_id: bool,
     wait_for_creation: bool = False,
     max_tries: int = MAX_TRIES,
+    progress: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -252,9 +344,20 @@ def evaluate_cluster(
     max_tries : int, optional
         The maximum number of tries to access the ExperimentData file, by
         default MAX_TRIES
+    progress : bool, optional
+        Accepted for API symmetry with the sequential and multiprocessing
+        evaluators (issue #234) but currently ignored on the cluster
+        path: each worker only sees its own samples, so a per-worker
+        tqdm bar would be misleading. Use
+        :meth:`ExperimentData.progress_summary` on the driver instead.
     kwargs : dict
         Any keyword arguments that need to be supplied to the function
     """
+    if progress:
+        logger.info(
+            "`progress=True` has no effect on the 'cluster' evaluator; "
+            "use ExperimentData.progress_summary() from the driver."
+        )
 
     # Creat lockfile
     lock_path = (
@@ -307,6 +410,7 @@ def evaluate_mpi(
     pass_id: bool,
     wait_for_creation: bool = False,
     max_tries: int = MAX_TRIES,
+    progress: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -329,9 +433,19 @@ def evaluate_mpi(
     max_tries : int, optional
         The maximum number of tries to access the ExperimentData file, by
         default MAX_TRIES
+    progress : bool, optional
+        Accepted for API symmetry with the sequential/parallel evaluators
+        (issue #234) but currently ignored under MPI for the same
+        reason it is ignored on the cluster path. Use
+        :meth:`ExperimentData.progress_summary` on the driver process.
     kwargs : dict
         Any keyword arguments that need to be supplied to the function
     """
+    if progress:
+        logger.info(
+            "`progress=True` has no effect on the 'mpi' evaluator; "
+            "use ExperimentData.progress_summary() from the driver."
+        )
     rank = comm.Get_rank()
     size = comm.Get_size()
 
@@ -357,6 +471,7 @@ def evaluate_cluster_array(
     data: ExperimentData,
     job_number: int,
     pass_id: bool,
+    progress: bool = False,
     **kwargs,
 ) -> None:
     """
@@ -373,9 +488,20 @@ def evaluate_cluster_array(
         The index of the specific job (array element) to run.
     pass_id : bool
         Whether to pass the job index to the execute function.
+    progress : bool, optional
+        Accepted for API symmetry (issue #234) but ignored: a single
+        array-job worker only runs its own sample, so a tqdm bar would
+        always be "0 of 1". Use :meth:`ExperimentData.progress_summary`
+        on the driver instead.
     **kwargs : dict
         Any keyword arguments that need to be supplied to the function.
     """
+    if progress:
+        logger.info(
+            "`progress=True` has no effect on the 'cluster_array' "
+            "evaluator; use ExperimentData.progress_summary() from the "
+            "driver."
+        )
 
     # Retrieve the experiment sample
     experiment_sample = data.get_experiment_sample(job_number)

--- a/src/f3dasm/_src/experimentdata.py
+++ b/src/f3dasm/_src/experimentdata.py
@@ -775,6 +775,31 @@ class ExperimentData:
         idx = [i for i, es in self if es.is_status(status)]
         return self[idx]
 
+    def progress_summary(self) -> dict[str, int]:
+        """Return a count of samples in each :class:`JobStatus`.
+
+        Provides a lightweight driver-side view of evaluation progress
+        that works regardless of which evaluator backend is in use --
+        most useful under the cluster, MPI, and cluster-array paths
+        where a per-worker tqdm bar is misleading (issue #234).
+
+        Returns
+        -------
+        dict[str, int]
+            Mapping of ``{"open", "in_progress", "finished", "error"}``
+            to the number of samples currently in that state.
+
+        Examples
+        --------
+        >>> summary = experiment_data.progress_summary()
+        >>> summary["finished"]
+        42
+        """
+        return {
+            status: len(self.select_with_status(status))
+            for status in ("open", "in_progress", "finished", "error")
+        }
+
     #                                                                    Export
     # =========================================================================
 

--- a/tests/datageneration/test_progress.py
+++ b/tests/datageneration/test_progress.py
@@ -1,0 +1,133 @@
+"""Regression tests for issue #234: optional tqdm progress bar plus
+driver-side ``ExperimentData.progress_summary``."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from f3dasm import ExperimentData, ExperimentSample, create_sampler
+from f3dasm._src.datagenerator import (
+    _progress_bar,
+    _progress_iter,
+    evaluate_multiprocessing,
+    evaluate_sequential,
+)
+from f3dasm.design import Domain
+
+pytestmark = pytest.mark.smoke
+
+
+def _square_fn(experiment_sample: ExperimentSample, **kwargs):
+    x = experiment_sample.get("x")
+    experiment_sample.store("y", x * x, to_disk=False)
+    return experiment_sample
+
+
+@pytest.fixture
+def small_data():
+    domain = Domain()
+    domain.add_float(name="x", low=0.0, high=1.0)
+    domain.add_output(name="y")
+    data = ExperimentData(domain=domain)
+    return create_sampler("random", seed=42).call(data=data, n_samples=4)
+
+
+class TestProgressHelpers:
+    def test_progress_bar_disabled_is_noop(self):
+        with _progress_bar(total=10, enabled=False, desc="x") as update:
+            update(3)  # must not error and must not require tqdm
+            update(1)
+
+    def test_progress_iter_disabled_returns_iterable(self):
+        items = [1, 2, 3]
+        wrapped = _progress_iter(items, total=3, enabled=False, desc="x")
+        assert list(wrapped) == items
+
+    def test_progress_bar_graceful_when_tqdm_missing(self, monkeypatch):
+        # Simulate tqdm not being installed: blocking the import returns
+        # ImportError and the helper must still yield a no-op update.
+        monkeypatch.setitem(sys.modules, "tqdm", None)
+        monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+        with _progress_bar(total=4, enabled=True, desc="x") as update:
+            update(2)
+            update(2)
+
+
+def test_evaluate_sequential_progress_silent_without_tqdm(
+    small_data, monkeypatch
+):
+    monkeypatch.setitem(sys.modules, "tqdm", None)
+    monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+    # Must run cleanly with progress=True even when tqdm is unavailable.
+    result = evaluate_sequential(
+        execute_fn=_square_fn,
+        data=small_data,
+        pass_id=False,
+        progress=True,
+    )
+    _, out = result.to_pandas()
+    assert len(out) == 4
+
+
+def test_evaluate_multiprocessing_progress_silent_without_tqdm(
+    small_data, monkeypatch
+):
+    monkeypatch.setitem(sys.modules, "tqdm", None)
+    monkeypatch.setitem(sys.modules, "tqdm.auto", None)
+    result = evaluate_multiprocessing(
+        execute_fn=_square_fn,
+        data=small_data,
+        pass_id=False,
+        nodes=2,
+        progress=True,
+    )
+    _, out = result.to_pandas()
+    assert len(out) == 4
+
+
+def test_progress_summary_reflects_status(small_data):
+    """`progress_summary` is the cluster/MPI-friendly view that works
+    regardless of evaluator."""
+    summary = small_data.progress_summary()
+    assert summary == {
+        "open": 4,
+        "in_progress": 0,
+        "finished": 0,
+        "error": 0,
+    }
+
+    # After evaluation the counts should shift to "finished".
+    evaluated = evaluate_sequential(
+        execute_fn=_square_fn, data=small_data, pass_id=False
+    )
+    summary = evaluated.progress_summary()
+    assert summary == {
+        "open": 0,
+        "in_progress": 0,
+        "finished": 4,
+        "error": 0,
+    }
+
+
+def test_progress_summary_keys_are_stable(small_data):
+    # Even when no samples are in a given state, the key must be present
+    # so downstream code (driver loops) can rely on the schema.
+    keys = set(small_data.progress_summary())
+    assert keys == {"open", "in_progress", "finished", "error"}
+
+
+def test_progress_bar_uses_tqdm_when_enabled():
+    """When `progress=True` and tqdm is importable, the helper must
+    actually emit a tqdm instance and tick it once per update."""
+    bar_instance = mock.MagicMock()
+    fake_tqdm = mock.MagicMock(return_value=bar_instance)
+    with mock.patch.dict(
+        sys.modules, {"tqdm.auto": mock.MagicMock(tqdm=fake_tqdm)}
+    ):
+        with _progress_bar(total=3, enabled=True, desc="x") as update:
+            update(1)
+            update(2)
+    fake_tqdm.assert_called_once_with(total=3, desc="x", leave=False)
+    assert bar_instance.update.call_count == 2
+    bar_instance.close.assert_called_once()


### PR DESCRIPTION
## Summary
Closes #234. Adds a `progress: bool = False` keyword across the `evaluate_*` family plus a driver-side `ExperimentData.progress_summary()` for the cases where a per-worker bar is misleading.

- **Sequential** wraps the open-job loop in a `tqdm` context that ticks once per completed sample.
- **Multiprocessing** switches to `pool.imap_unordered` so the bar advances as workers finish, then restores ordering on `job_number` when writing back.
- **Cluster / MPI / cluster_array** accept the keyword to keep the dispatch signature uniform — preventing `progress=True` from leaking into the user's data-generator function — but they treat it as a no-op with an info-level log, because a per-worker bar lies in those modes. Use `ExperimentData.progress_summary()` from the driver instead.
- `progress_summary()` returns the count of samples in each `JobStatus`. The schema is stable regardless of which counts are zero, so driver loops can rely on the four keys (`open`, `in_progress`, `finished`, `error`).
- `tqdm` is a new optional extra (`pip install f3dasm[progress]`) and also rolled into `all`. Import is lazy: missing tqdm degrades gracefully to silent execution with a single info-level warning.

## Test plan
- [x] `uv run pytest tests/datageneration/ tests/experimentdata/ --no-cov` — 683 passed (8 new in `test_progress.py`).
- [x] New tests cover: helper-disabled no-op, graceful degradation when tqdm is missing, end-to-end sequential and multiprocessing with `progress=True`, `progress_summary` snapshot + key stability, and a mock-based check that tqdm is actually used when present.
- [x] `uv run pre-commit run --files src/f3dasm/_src/datagenerator.py src/f3dasm/_src/experimentdata.py pyproject.toml tests/datageneration/test_progress.py` — clean.

Fix #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)