### PR TITLE
refactor: unify evaluate_* positional signatures

### DIFF
--- a/src/f3dasm/_src/datagenerator.py
+++ b/src/f3dasm/_src/datagenerator.py
@@ -302,7 +302,6 @@ def evaluate_cluster(
 
 def evaluate_mpi(
     execute_fn: Callable[..., ExperimentSample],
-    comm,
     data: ExperimentData,
     pass_id: bool,
     wait_for_creation: bool = False,
@@ -317,8 +316,6 @@ def evaluate_mpi(
     ----------
     execute_fn : Callable[..., ExperimentSample]
         The function to be executed on each ExperimentSample
-    comm : MPI.Comm
-        The MPI communicator
     data : ExperimentData
         The ExperimentData object containing the samples to be processed
     pass_id : bool
@@ -330,8 +327,25 @@ def evaluate_mpi(
         The maximum number of tries to access the ExperimentData file, by
         default MAX_TRIES
     kwargs : dict
-        Any keyword arguments that need to be supplied to the function
+        Any keyword arguments that need to be supplied to the function.
+        Must include ``comm`` (the ``MPI.Comm`` instance) -- pulled out
+        here rather than being a positional parameter so every
+        ``evaluate_*`` function shares the same
+        ``(execute_fn, data, pass_id, **kwargs)`` shape (issue #309).
+
+    Raises
+    ------
+    TypeError
+        If ``comm`` was not supplied in ``kwargs``.
     """
+    try:
+        comm = kwargs.pop("comm")
+    except KeyError as exc:
+        raise TypeError(
+            "evaluate_mpi requires the MPI communicator via "
+            "`comm=...`; pass it as a keyword argument."
+        ) from exc
+
     rank = comm.Get_rank()
     size = comm.Get_size()
 
@@ -355,7 +369,6 @@ def evaluate_mpi(
 def evaluate_cluster_array(
     execute_fn: Callable[..., ExperimentSample],
     data: ExperimentData,
-    job_number: int,
     pass_id: bool,
     **kwargs,
 ) -> None:
@@ -369,13 +382,27 @@ def evaluate_cluster_array(
         The function to be executed on each ExperimentSample.
     data : ExperimentData
         The ExperimentData object containing the samples to be processed.
-    job_number : int
-        The index of the specific job (array element) to run.
     pass_id : bool
         Whether to pass the job index to the execute function.
     **kwargs : dict
         Any keyword arguments that need to be supplied to the function.
+        Must include ``job_number`` (the array index to run) -- pulled
+        out of ``kwargs`` here rather than being a positional parameter
+        so every ``evaluate_*`` function shares the same
+        ``(execute_fn, data, pass_id, **kwargs)`` shape (issue #309).
+
+    Raises
+    ------
+    TypeError
+        If ``job_number`` was not supplied in ``kwargs``.
     """
+    try:
+        job_number = kwargs.pop("job_number")
+    except KeyError as exc:
+        raise TypeError(
+            "evaluate_cluster_array requires the array index via "
+            "`job_number=...`; pass it as a keyword argument."
+        ) from exc
 
     # Retrieve the experiment sample
     experiment_sample = data.get_experiment_sample(job_number)

--- a/tests/datageneration/test_datagenerator_modes.py
+++ b/tests/datageneration/test_datagenerator_modes.py
@@ -222,6 +222,68 @@ class TestEvaluateClusterArray:
         json_files = list(subfolder.glob("*.json"))
         assert len(json_files) >= 1
 
+    def test_cluster_array_missing_job_number_raises(self, stored_data):
+        """Issue #309: `job_number` is now a kwargs-only parameter.
+        Omitting it must raise a clear TypeError rather than a confusing
+        KeyError from somewhere deep in the call."""
+        with pytest.raises(TypeError, match="job_number"):
+            evaluate_cluster_array(
+                execute_fn=_square_fn,
+                data=stored_data,
+                pass_id=False,
+            )
+
+
+# ===== unified signature contract (#309) ==================================
+
+
+class TestUnifiedEvaluateSignatures:
+    """Issue #309: all five `evaluate_*` functions must share the same
+    leading positional shape `(execute_fn, data, pass_id, **kwargs)` so
+    `DataGenerator.call`'s dispatch can hand them off identically."""
+
+    @pytest.mark.parametrize(
+        "func_name",
+        [
+            "evaluate_sequential",
+            "evaluate_multiprocessing",
+            "evaluate_cluster",
+            "evaluate_mpi",
+            "evaluate_cluster_array",
+        ],
+    )
+    def test_first_three_positional_are_uniform(self, func_name):
+        import inspect
+
+        from f3dasm._src import datagenerator
+
+        sig = inspect.signature(getattr(datagenerator, func_name))
+        params = list(sig.parameters.values())
+        # First three positional parameters: execute_fn, data, pass_id
+        names = [p.name for p in params[:3]]
+        assert names == ["execute_fn", "data", "pass_id"]
+
+    @pytest.mark.parametrize(
+        "func_name",
+        [
+            "evaluate_sequential",
+            "evaluate_multiprocessing",
+            "evaluate_cluster",
+            "evaluate_mpi",
+            "evaluate_cluster_array",
+        ],
+    )
+    def test_each_evaluator_accepts_var_keyword(self, func_name):
+        import inspect
+
+        from f3dasm._src import datagenerator
+
+        sig = inspect.signature(getattr(datagenerator, func_name))
+        kinds = {p.kind for p in sig.parameters.values()}
+        assert inspect.Parameter.VAR_KEYWORD in kinds, (
+            f"{func_name} no longer accepts **kwargs"
+        )
+
 
 class TestEvaluateMPI:
     def test_mpi_rank_zero_calls_lock_manager(self, simple_data):


### PR DESCRIPTION
## Summary
Closes #309. The five `evaluate_*` functions formerly disagreed on the positional shape after `execute_fn`. `evaluate_mpi` inserted `comm` at index 1; `evaluate_cluster_array` inserted `job_number` at index 2. Both forced `DataGenerator.call` to know each mode's positional contract.

- Standardise on `(execute_fn, data, pass_id, **kwargs)` across all five functions.
- `evaluate_mpi` now pulls `comm = kwargs.pop("comm")` and `evaluate_cluster_array` pulls `job_number = kwargs.pop("job_number")` at the top of the function. Missing values surface as a clean `TypeError` (`evaluate_mpi requires the MPI communicator via \`comm=...\``) rather than a deep `KeyError`.
- `DataGenerator.call` already dispatched everything as keyword arguments, so no caller update is needed. Existing tests already passed `comm=` and `job_number=` as keywords.

## Test plan
- [x] `uv run pytest tests/datageneration/ --no-cov` — 81 passed
- [x] New `test_cluster_array_missing_job_number_raises` checks the clean `TypeError`
- [x] New `TestUnifiedEvaluateSignatures` parametrises across all five evaluators and asserts (a) the first three positional parameters are `(execute_fn, data, pass_id)` and (b) each accepts `**kwargs` — a contract pin so the next change can't silently regress
- [x] `uv run pre-commit run ...` — clean

## Notes for reviewers
- This is the third branch in the `datagenerator.py` triplet (`#247 → #234 → #309`). Both prior branches are open against `develop`; once one merges, the next will need a rebase. No conflict expected in `_run_sample` or the helpers.

Fix #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)