### PR TITLE
feat: explicit sampler names + validated factory kwargs (QoL #289)

### DIFF
--- a/src/f3dasm/_src/samplers.py
+++ b/src/f3dasm/_src/samplers.py
@@ -1009,9 +1009,29 @@ def grid(
 
 _SAMPLERS = [random, latin, sobol, grid]
 
+# Issue #289 sub-item 1: prefer explicit `<name>_sampler` keys over the
+# bare short names. The short names still work but emit a
+# DeprecationWarning so users can migrate at their own pace.
 SAMPLER_MAPPING: dict[str, Block] = {
     sampler.__name__.lower(): sampler for sampler in _SAMPLERS
 }
+SAMPLER_MAPPING.update(
+    {f"{sampler.__name__.lower()}sampler": sampler for sampler in _SAMPLERS}
+)
+
+# Per-backend documented `parameters` allow-list (issue #289 sub-item 2).
+# Keys are filtered names (after stripping spaces, dashes, underscores);
+# values are the documented kwargs each sampler accepts. Unknown kwargs
+# now raise a TypeError instead of being silently swallowed.
+SAMPLER_PARAMETERS: dict[str, set[str]] = {
+    "random": {"seed"},
+    "latin": {"seed"},
+    "sobol": {"seed"},
+    "grid": {"stepsize_continuous_parameters"},
+}
+SAMPLER_PARAMETERS.update(
+    {f"{name}sampler": kw for name, kw in list(SAMPLER_PARAMETERS.items())}
+)
 
 #                                                              Factory function
 # =============================================================================
@@ -1023,13 +1043,27 @@ def create_sampler(sampler: str | DictConfig, **parameters) -> Block:
 
     Parameters
     ----------
-    sampler : str | Block | DictConfig
-        name of the built-in sampler. This can be a string with the name of the
-        sampler, a Block object (this will just by-pass the function), or a
-        DictConfig object (the sampler will be instantiated with
-        hydra.instantiate).
+    sampler : str | DictConfig
+        Name of the built-in sampler. Accepted values (issue #289):
+
+        - ``"random_sampler"`` (preferred) or ``"random"`` (deprecated):
+          uniform random sampling. Accepted ``parameters``: ``seed``.
+        - ``"latin_sampler"`` (preferred) or ``"latin"`` (deprecated):
+          Latin-Hypercube sampling. Accepted ``parameters``: ``seed``.
+        - ``"sobol_sampler"`` (preferred) or ``"sobol"`` (deprecated):
+          Sobol low-discrepancy sequence sampling. Accepted
+          ``parameters``: ``seed``.
+        - ``"grid_sampler"`` (preferred) or ``"grid"`` (deprecated): full
+          cross-product grid. Accepted ``parameters``:
+          ``stepsize_continuous_parameters``.
+
+        Can also be a Hydra ``DictConfig`` that instantiates a sampler
+        block directly.
     **parameters
-        Additional keyword arguments passed when initializing the sampler
+        Additional keyword arguments passed when initializing the sampler.
+        Only the keywords documented per-backend above are accepted; any
+        other keyword raises a ``TypeError`` so typos and stale options
+        do not silently get ignored.
 
     Returns
     -------
@@ -1041,7 +1075,9 @@ def create_sampler(sampler: str | DictConfig, **parameters) -> Block:
     KeyError
         If the built-in sampler name is not recognized.
     TypeError
-        If the given type is not recognized.
+        If ``sampler`` is not a ``str`` or ``DictConfig``, or if
+        ``parameters`` contains a keyword the chosen backend does not
+        accept.
     """
     if isinstance(sampler, str):
         filtered_name = (
@@ -1049,6 +1085,11 @@ def create_sampler(sampler: str | DictConfig, **parameters) -> Block:
         )
 
         if filtered_name in SAMPLER_MAPPING:
+            # Old, short keys (issue #289): emit a DeprecationWarning so
+            # users can move to the explicit `<name>_sampler` form.
+            if not filtered_name.endswith("sampler"):
+                _warn_deprecated_sampler_name(sampler)
+            _validate_sampler_parameters(filtered_name, parameters)
             return SAMPLER_MAPPING[filtered_name](**parameters)
 
         else:
@@ -1061,4 +1102,51 @@ def create_sampler(sampler: str | DictConfig, **parameters) -> Block:
         raise TypeError(f"Unknown sampler type given: {type(sampler)}")
 
 
-SamplerNames = Literal["random", "latin", "sobol", "grid"]
+def _warn_deprecated_sampler_name(name: str) -> None:
+    """Warn that a bare short sampler name is being used.
+
+    Recommends migrating to the ``<name>_sampler`` form added in issue
+    #289. Lives in a helper so the deprecation can be silenced in tests
+    via ``warnings.simplefilter("error", DeprecationWarning)``.
+    """
+    import warnings
+
+    warnings.warn(
+        f"Sampler name {name!r} is deprecated and will be removed in a "
+        f"future release; use {name + '_sampler'!r} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _validate_sampler_parameters(
+    filtered_name: str, parameters: dict[str, object]
+) -> None:
+    """Reject keywords the chosen sampler doesn't accept (issue #289).
+
+    Compares the supplied keys against the per-backend allow-list in
+    :data:`SAMPLER_PARAMETERS` and raises ``TypeError`` if anything is
+    unknown. Without this check a typo like ``seedz=42`` was silently
+    swallowed by the factory's ``**parameters``.
+    """
+    allowed = SAMPLER_PARAMETERS.get(filtered_name)
+    if allowed is None:
+        return
+    unknown = set(parameters) - allowed
+    if unknown:
+        raise TypeError(
+            f"Sampler {filtered_name!r} does not accept "
+            f"keyword(s) {sorted(unknown)}. Accepted: {sorted(allowed)}."
+        )
+
+
+SamplerNames = Literal[
+    "random",
+    "latin",
+    "sobol",
+    "grid",
+    "random_sampler",
+    "latin_sampler",
+    "sobol_sampler",
+    "grid_sampler",
+]

--- a/tests/sampling/test_sampling_extended.py
+++ b/tests/sampling/test_sampling_extended.py
@@ -59,6 +59,70 @@ def test_create_sampler_grid():
     assert sampler is not None
 
 
+# ===== explicit sampler names + kwargs allow-list (#289 sub-items 1 & 2) =====
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["random_sampler", "latin_sampler", "sobol_sampler", "grid_sampler"],
+)
+def test_create_sampler_accepts_explicit_alias(name):
+    """The explicit `<name>_sampler` form added in issue #289 must
+    return the same backend block as the legacy short name."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        if name == "grid_sampler":
+            sampler = create_sampler(name)
+        else:
+            sampler = create_sampler(name, seed=42)
+    assert sampler is not None
+
+
+@pytest.mark.parametrize(
+    ("old_name", "new_name"),
+    [
+        ("random", "random_sampler"),
+        ("latin", "latin_sampler"),
+        ("sobol", "sobol_sampler"),
+        ("grid", "grid_sampler"),
+    ],
+)
+def test_create_sampler_short_name_warns(old_name, new_name):
+    """Issue #289 sub-item 1: bare short names emit a DeprecationWarning
+    pointing at the explicit alias."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        kwargs = {} if old_name == "grid" else {"seed": 42}
+        create_sampler(old_name, **kwargs)
+
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecations) == 1
+    msg = str(deprecations[0].message)
+    assert old_name in msg
+    assert new_name in msg
+
+
+def test_create_sampler_rejects_unknown_kwarg():
+    """Issue #289 sub-item 2: typos like `seedz=42` were silently
+    swallowed by the factory's `**parameters`. The allow-list now
+    raises TypeError naming the accepted keywords."""
+    with pytest.raises(TypeError, match=r"keyword\(s\) \['seedz'\]"):
+        create_sampler("random_sampler", seedz=42)
+
+
+def test_create_sampler_grid_rejects_seed():
+    """Per the per-backend allow-list, `seed` is not a valid argument
+    for the grid sampler -- the factory must say so eagerly."""
+    with pytest.raises(TypeError, match="seed"):
+        create_sampler("grid_sampler", seed=42)
+
+
 # ======================= next_power_of_two =======================
 
 


### PR DESCRIPTION
## Summary
Issue #289 collected four QoL items. This PR addresses two; the other two are documented in the commit message as either already-done or pending clarification.

**Sub-item 1 — explicit sampler names.** Adds `random_sampler`, `latin_sampler`, `sobol_sampler`, `grid_sampler` aliases. The legacy short keys still work but now emit `DeprecationWarning` pointing at the new name.

**Sub-item 2 — validated factory kwargs.** `create_sampler(sampler, **parameters)` previously swallowed any keyword. Typos like `seedz=42` quietly built a sampler with default seed; stale options from older releases quietly survived an upgrade. A per-backend allow-list (`SAMPLER_PARAMETERS`) now rejects unknown keywords with a clear `TypeError("Sampler 'random' does not accept keyword(s) ['seedz']. Accepted: ['seed'].")`. The accepted keywords are spelled out per-backend in the `create_sampler` docstring.

**Sub-item 3 — unify Block execution.** Skipped pending clarification. The triage flagged that `ExperimentData.run` is already gone on develop, leaving `Block.call(data=...)` as the only canonical entry. If a third path actually exists I'll revisit in a follow-up.

**Sub-item 4 — explicit `experiment_sample` arg.** Already done on develop: `DataGenerator.execute(self, experiment_sample, **kwargs)` takes the sample as an explicit parameter; no `self.experiment_sample` references remain in `src/`. No change required.

## Test plan
- [x] `uv run pytest tests/ --no-cov` — 1069 passed (10 new in `test_sampling_extended.py`)
- [x] Parametrised: every new `<name>_sampler` alias resolves without warning
- [x] Parametrised: every legacy bare name warns with both old and new name in the message
- [x] `create_sampler(..., seedz=42)` raises `TypeError` naming the unknown keyword
- [x] `create_sampler("grid_sampler", seed=42)` raises because `seed` isn't on the grid sampler's allow-list
- [x] `uv run pre-commit run ...` — clean

## Notes for reviewers
- The DeprecationWarning lands now so existing callers see it for one minor; we can remove the short keys in a future release once user code has migrated.
- Adding a `SAMPLER_PARAMETERS` allow-list pins the *intent* of each backend's surface area. If a new sampler keyword is added in the future, it needs to be added to the allow-list too — this is by design.

Fix #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)