### PR TITLE
fix(slurm): count open experiments after each inner loop step runs

### DIFF
--- a/src/f3dasm/_src/pipeline/executors/slurm.py
+++ b/src/f3dasm/_src/pipeline/executors/slurm.py
@@ -205,7 +205,7 @@ class SlurmExecutor(Executor):
         orch_path.write_text(orch_script)
 
         # --- Submit the orchestrator ---
-        cmd: list[str] = ["sbatch", str(orch_path), "0", "0"]
+        cmd: list[str] = ["sbatch", str(orch_path), "0", "0", "0"]
         logger.info(f"Submitting orchestrator: {' '.join(cmd)}")
         result = subprocess.run(
             cmd, capture_output=True, text=True, check=True
@@ -417,19 +417,27 @@ def render_orchestrator_script(
 ) -> str:
     """Render a self-resubmitting orchestrator for the pipeline.
 
-    The orchestrator manages the entire pipeline using two
+    The orchestrator manages the entire pipeline using three
     counters passed as positional arguments:
 
     - ``STEP_COUNT``: index into the pipeline's top-level
       elements (Steps and Loops).
     - ``LOOP_COUNT``: current iteration within a Loop (0 when
       not inside a loop).
+    - ``INNER_COUNT``: index of the inner step within the
+      current Loop iteration (0 when not inside a loop).
 
     Each execution handles exactly one action (one Step
-    submission or one Loop iteration), then resubmits itself
-    with ``--dependency`` on the last submitted job. The
-    dependency type is determined by the *next* step's
-    ``Step.dependency`` field; after the last element the
+    submission, or one inner step of one Loop iteration), then
+    resubmits itself with ``--dependency`` on the last submitted
+    job. Submitting each inner Loop step in its own wake (rather
+    than all of an iteration's steps at once) ensures a parallel
+    inner step sizes its ``--array=`` via
+    :mod:`f3dasm.pipeline.count_open` only *after* its upstream
+    inner step has finished writing its ExperimentData to disk --
+    the same guarantee top-level step transitions already
+    provide. The dependency type is determined by the *next*
+    step's ``Step.dependency`` field; after the last element the
     orchestrator resubmits itself once more with ``afterok``, so
     a final run starts past ``TOTAL_STEPS`` and prints
     ``"Pipeline complete."`` to its log if (and only if) the
@@ -508,6 +516,7 @@ def render_orchestrator_script(
         [
             "STEP_COUNT=$1",
             "LOOP_COUNT=$2",
+            "INNER_COUNT=${3:-0}",
             'SELF=$(realpath "$0")',
             f"TOTAL_STEPS={total_steps}",
             f'JOB_DIR="{job_dir.as_posix()}"',
@@ -702,94 +711,115 @@ def _render_loop_block(
     script_paths: dict[str, str],
     total_steps: int,
 ) -> None:
-    """Append bash lines for a Loop element in the orchestrator."""
+    """Append bash lines for a Loop element in the orchestrator.
+
+    Each inner step is submitted in its *own* orchestrator wake,
+    tracked by ``INNER_COUNT`` and chained by a SLURM dependency on
+    the previous inner step. This guarantees a parallel inner step's
+    :mod:`f3dasm.pipeline.count_open` runs only after its predecessor
+    has finished writing its ExperimentData to disk -- the invariant
+    top-level step transitions already rely on. Submitting all of an
+    iteration's inner steps in a single wake (the previous behaviour)
+    would size a parallel step's ``--array=`` from the *previous*
+    iteration's residual job statuses, before the current iteration's
+    upstream step had run.
+    """
     n_iters = loop.n_iterations
+    next_step_index = step_index + 1
 
     lines.extend(
         [
             f"    # Loop: {n_iters} iterations",
             f'    if [ "$LOOP_COUNT" -lt {n_iters} ]; then',
             "      export F3DASM_ITERATION=$LOOP_COUNT",
-            '      PREV_JOB_ID=""',
         ]
     )
 
-    # Submit each inner step with dependency chaining
+    if not loop.steps:
+        # Degenerate loop with no inner steps: advance the iteration
+        # counter without submitting anything (a no-op per iteration,
+        # preserving the prior behaviour for empty loops).
+        lines.extend(
+            [
+                "      LOOP_COUNT=$((LOOP_COUNT + 1))",
+                '      sbatch "$SELF" $STEP_COUNT $LOOP_COUNT 0',
+                "      exit 0",
+                "    else",
+                "      LOOP_COUNT=0",
+                "      INNER_COUNT=0",
+                f"      STEP_COUNT={next_step_index}",
+                "      continue",
+                "    fi",
+            ]
+        )
+        return
+
+    n_inner = len(loop.steps)
     for j, inner_step in enumerate(loop.steps):
         inner_label = f"loop{step_index}_{inner_step.name}"
         inner_path = script_paths[inner_label]
         log_label = f"{inner_step.name} (iter $LOOP_COUNT)"
-        dep = inner_step.dependency
+        cond = "if" if j == 0 else "elif"
 
-        lines.append(f"      # Inner step: {inner_step.name}")
+        lines.append(f'      {cond} [ "$INNER_COUNT" -eq {j} ]; then')
+        lines.append(f"        # Inner step: {inner_step.name}")
 
+        # --- Submit this inner step -> JOB_ID (empty if skipped). The
+        # cross-step ordering is enforced by the dependency on the SELF
+        # resubmission that gated *this* wake, so the step itself only
+        # needs --export=ALL (no carry-in --dependency flag).
         if inner_step.parallel:
-            # Build the optional --dependency= flag.
-            if j == 0:
-                dep_flag_setup = ['      DEP_FLAG="--export=ALL"']
-            else:
-                dep_flag_setup = [
-                    '      if [ -n "$PREV_JOB_ID" ]; then',
-                    f'        DEP_FLAG="--dependency={dep}:$PREV_JOB_ID'
-                    ' --export=ALL"',
-                    "      else",
-                    '        DEP_FLAG="--export=ALL"',
-                    "      fi",
-                ]
-            lines.extend(dep_flag_setup)
             _render_parallel_submit(
                 lines=lines,
                 step=inner_step,
                 cluster=cluster,
                 script_path=inner_path,
                 label_for_log=f"  {log_label}",
-                job_id_var="PREV_JOB_ID",
-                indent="      ",
-                extra_sbatch_flags="$DEP_FLAG",
-            )
-        elif j == 0:
-            # First inner non-parallel step: no carry-in dep
-            lines.extend(
-                [
-                    f'      RESULT=$(sbatch --export=ALL "{inner_path}")',
-                    "      PREV_JOB_ID=$(echo $RESULT | awk '{print $NF}')",
-                    f'      echo "  Submitted {log_label}: job $PREV_JOB_ID"',
-                ]
+                job_id_var="JOB_ID",
+                indent="        ",
+                extra_sbatch_flags="--export=ALL",
             )
         else:
             lines.extend(
                 [
-                    '      if [ -n "$PREV_JOB_ID" ]; then',
-                    "        RESULT=$(sbatch"
-                    f" --dependency={dep}:$PREV_JOB_ID"
-                    f' --export=ALL "{inner_path}")',
-                    "      else",
                     f'        RESULT=$(sbatch --export=ALL "{inner_path}")',
-                    "      fi",
-                    "      PREV_JOB_ID=$(echo $RESULT | awk '{print $NF}')",
-                    f'      echo "  Submitted {log_label}: job $PREV_JOB_ID"',
+                    "        JOB_ID=$(echo $RESULT | awk '{print $NF}')",
+                    f'        echo "  Submitted {log_label}: job $JOB_ID"',
                 ]
             )
 
-    # Resubmit orchestrator for next iteration
-    # Use the first inner step's dependency type for iteration
-    # resubmission (determines if next iteration runs on failure)
-    iter_dep = loop.steps[0].dependency if loop.steps else "afterok"
+        # --- Resubmit SELF for the next inner step, or (after the last
+        # inner step) for the next iteration. The target step's
+        # ``dependency`` field decides how it depends on this one.
+        if j < n_inner - 1:
+            next_dep = loop.steps[j + 1].dependency
+            self_args = f"$STEP_COUNT $LOOP_COUNT {j + 1}"
+        else:
+            next_dep = loop.steps[0].dependency
+            self_args = "$STEP_COUNT $((LOOP_COUNT + 1)) 0"
+
+        # A skipped parallel step leaves JOB_ID empty -> resubmit
+        # without a SLURM dependency.
+        lines.extend(
+            [
+                '        if [ -n "$JOB_ID" ]; then',
+                f"          sbatch --dependency={next_dep}:$JOB_ID"
+                f' "$SELF" {self_args}',
+                "        else",
+                f'          sbatch "$SELF" {self_args}',
+                "        fi",
+                "        exit 0",
+            ]
+        )
 
     lines.extend(
         [
-            "      LOOP_COUNT=$((LOOP_COUNT + 1))",
-            '      if [ -n "$PREV_JOB_ID" ]; then',
-            f"        sbatch --dependency={iter_dep}:$PREV_JOB_ID"
-            ' "$SELF" $STEP_COUNT $LOOP_COUNT',
-            "      else",
-            '        sbatch "$SELF" $STEP_COUNT $LOOP_COUNT',
             "      fi",
-            "      exit 0",
             "    else",
             "      # Loop done — advance to next element",
             "      LOOP_COUNT=0",
-            f"      STEP_COUNT={step_index + 1}",
+            "      INNER_COUNT=0",
+            f"      STEP_COUNT={next_step_index}",
             "      continue",
             "    fi",
         ]

--- a/tests/pipeline/test_slurm.py
+++ b/tests/pipeline/test_slurm.py
@@ -293,8 +293,122 @@ class TestRenderLoopBlock:
         text = "\n".join(lines)
         assert "f3dasm.pipeline.count_open" in text
         assert "--array=0-${ARRAY_MAX}%64" in text
-        # PREV_JOB_ID is set/used conditionally for chaining
-        assert 'if [ -n "$PREV_JOB_ID" ]; then' in text
+        # A skipped parallel inner step empties JOB_ID and resubmits
+        # without a dependency (the gen-then-post chaining is carried by
+        # the per-inner-step SELF resubmission, not an in-wake PREV_JOB_ID).
+        assert 'JOB_ID=""' in text
+        assert 'if [ -n "$JOB_ID" ]; then' in text
+
+    def test_parallel_inner_step_counts_open_after_predecessor(self, cluster):
+        # Regression: a parallel inner step's count_open must run in a
+        # *separate* wake from (and gated on) its non-parallel predecessor,
+        # so the array width reflects what the predecessor just wrote --
+        # not the previous iteration's residual job statuses.
+        res = SlurmResources(max_array_size=900, max_concurrent=64)
+        sub = Step(block=lambda: None, name="subsample", dependency="afterok")
+        run = Step(
+            block=lambda: None,
+            name="run",
+            parallel=True,
+            resources=res,
+            dependency="afterok",
+        )
+        post = Step(block=lambda: None, name="post", dependency="afterany")
+        loop = Loop(n_iterations=4, steps=[sub, run, post])
+        p = Pipeline(steps=[loop])
+        lines = []
+        _render_loop_block(
+            lines=lines,
+            loop=loop,
+            step_index=0,
+            pipeline=p,
+            cluster=cluster,
+            script_paths={
+                "loop0_subsample": "/s/sub.sh",
+                "loop0_run": "/s/run.sh",
+                "loop0_post": "/s/post.sh",
+            },
+            total_steps=1,
+        )
+        text = "\n".join(lines)
+        assert 'if [ "$INNER_COUNT" -eq 0 ]' in text
+        assert 'elif [ "$INNER_COUNT" -eq 1 ]' in text
+        assert 'elif [ "$INNER_COUNT" -eq 2 ]' in text
+        seg0 = text[
+            text.index('if [ "$INNER_COUNT" -eq 0 ]') : text.index(
+                'elif [ "$INNER_COUNT" -eq 1 ]'
+            )
+        ]
+        seg1 = text[
+            text.index('elif [ "$INNER_COUNT" -eq 1 ]') : text.index(
+                'elif [ "$INNER_COUNT" -eq 2 ]'
+            )
+        ]
+        # subsample wake submits the script but never counts open ...
+        assert "/s/sub.sh" in seg0
+        assert "count_open" not in seg0
+        # ... and run's count_open lives only in the next (gated) wake.
+        assert "count_open" in seg1
+        assert "/s/run.sh" in seg1
+
+    def test_inner_steps_thread_inner_count(self, cluster):
+        # Each inner step resubmits the orchestrator for the next inner
+        # index (gated by the *next* step's dependency); the last inner
+        # step advances the iteration and resets INNER_COUNT to 0.
+        sub = Step(block=lambda: None, name="subsample", dependency="afterok")
+        run = Step(block=lambda: None, name="run", dependency="afterok")
+        post = Step(block=lambda: None, name="post", dependency="afterany")
+        loop = Loop(n_iterations=4, steps=[sub, run, post])
+        p = Pipeline(steps=[loop])
+        lines = []
+        _render_loop_block(
+            lines=lines,
+            loop=loop,
+            step_index=0,
+            pipeline=p,
+            cluster=cluster,
+            script_paths={
+                "loop0_subsample": "/s/sub.sh",
+                "loop0_run": "/s/run.sh",
+                "loop0_post": "/s/post.sh",
+            },
+            total_steps=1,
+        )
+        text = "\n".join(lines)
+        # subsample -> run (run.dependency == afterok), next inner index 1
+        assert (
+            'sbatch --dependency=afterok:$JOB_ID "$SELF"'
+            " $STEP_COUNT $LOOP_COUNT 1" in text
+        )
+        # run -> post (post.dependency == afterany), next inner index 2
+        assert (
+            'sbatch --dependency=afterany:$JOB_ID "$SELF"'
+            " $STEP_COUNT $LOOP_COUNT 2" in text
+        )
+        # post (last) -> next iteration (steps[0].dependency == afterok),
+        # LOOP_COUNT + 1 and INNER_COUNT reset to 0
+        assert (
+            'sbatch --dependency=afterok:$JOB_ID "$SELF"'
+            " $STEP_COUNT $((LOOP_COUNT + 1)) 0" in text
+        )
+        assert "INNER_COUNT=0" in text
+
+    def test_empty_loop_advances_without_submitting(self, cluster):
+        loop = Loop(n_iterations=3, steps=[])
+        p = Pipeline(steps=[loop, Step(block=lambda: None, name="after")])
+        lines = []
+        _render_loop_block(
+            lines=lines,
+            loop=loop,
+            step_index=0,
+            pipeline=p,
+            cluster=cluster,
+            script_paths={},
+            total_steps=2,
+        )
+        text = "\n".join(lines)
+        assert 'sbatch "$SELF" $STEP_COUNT $LOOP_COUNT 0' in text
+        assert "STEP_COUNT=1" in text
 
 
 class TestRenderOrchestratorScript:
@@ -314,6 +428,7 @@ class TestRenderOrchestratorScript:
         assert "orchestrator_test" in script
         assert "STEP_COUNT=$1" in script
         assert "LOOP_COUNT=$2" in script
+        assert "INNER_COUNT=${3:-0}" in script
         assert "TOTAL_STEPS=1" in script
         assert 'JOB_DIR="/scratch/job1"' in script
         assert "Pipeline complete" in script


### PR DESCRIPTION
## Problem

Inside an f3dasm `Loop`, the SLURM orchestrator submits **all** of an iteration's inner steps in a single wake, chained only by SLURM dependencies. For a *parallel* inner step, `count_open` — which both sizes the `--array=` width and decides whether the step is submitted at all — is emitted **inline at submission time**, right after `sbatch`-ing the upstream inner step. But `sbatch` only *queues* that upstream job; it hasn't run yet. So the open-count reflects the **previous iteration's residual job statuses**, not the rows the upstream step is about to mark `open`.

Concretely, in the online-multitask training loop (`subsample_tasks` → `run` *(parallel)* → `post`):

- `run`'s open-count is read before `subsample_tasks` executes → on iterations where the prior iteration ended with every row `finished`, the count is `0` and `run` is **skipped** ("no open experiments") even though `subsample_tasks` opens the tasks moments later.
- Once `run` is skipped, no `experience` is produced, so the downstream `DAACUpdate` aggregates an empty `finished` set and crashes (`xr.open_mfdataset([])`). `post` exits non-zero, the orchestrator's `--dependency=afterok:<post>` self-resubmission can never be satisfied, and the loop **silently halts**.

`count_open`'s documented contract — *"after the upstream step has finished writing its ExperimentData to disk"* — holds for top-level step→step transitions (each is a separate, dependency-gated wake) but was **violated for step→step transitions inside a Loop**.

## Fix

Add a third orchestrator counter, **`INNER_COUNT`**, and submit each inner loop step in its **own wake**, gated by a SLURM dependency on the prior inner step (mirroring how top-level steps already work). A parallel inner step's `count_open` therefore runs only *after* its predecessor has finished writing to disk. This also fixes the case where a loop's first inner step is parallel.

- `_render_loop_block` now dispatches on `INNER_COUNT` (`if [ "$INNER_COUNT" -eq 0 ]` / `elif … -eq 1` / …); each wake submits one inner step and resubmits the orchestrator for the next inner index with `--dependency=<next_step.dependency>:$JOB_ID`. The last inner step advances `LOOP_COUNT` and resets `INNER_COUNT=0`.
- The old in-wake `PREV_JOB_ID`/`DEP_FLAG` chaining is removed (ordering is now carried by the SELF-resubmit dependency, so each step just needs `--export=ALL`).
- Empty-loop guard preserved; initial submit and `render_orchestrator_script` docstring updated for the new counter.

## Verification

- **End-to-end bash simulation** (mock `sbatch` executing submitted scripts in dependency order, stub `count_open`/workers): from the worst-case initial state (0 open rows = post-create all-`finished`), the parallel step is submitted on **all 10 iterations, 0 skips**, and the pipeline reaches `Pipeline complete.` — the exact scenario that was stalling.
- `bash -n` on the rendered orchestrator: clean.
- New regression tests in `tests/pipeline/test_slurm.py`: `count_open` lives in a different `INNER_COUNT` branch than its predecessor's submit; per-inner-step counter threading + dependency types; iteration rollover; empty-loop case.
- `uv run pytest tests/pipeline/` → 80 passed; full smoke suite → 1087 passed; `ruff check`/`ruff format --check` clean.

## Compatibility

- Orchestrator scripts are regenerated on every `Pipeline.run`, so there is **no migration** for persisted scripts; in-flight runs keep their old orchestrator and are unaffected — only new submissions get the fix.
- Cost: a loop of *I* iterations × *S* inner steps now uses *I·S* tiny orchestrator wakes (e.g. 10×3=30 vs 10). Each is a seconds-long, low-resource job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)