### PR TITLE
Unify executor step dispatch behind run_step + ExecutionContext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,17 @@ Optional deps (`optuna`, `abaqus2py`) are gated behind the `all` extra and behin
 - [agentic-l2co](https://github.com/bessagroup/agentic-l2co) — An LLM-agent drop-in replacement for `l2co.L2COModel`, driving two-stage optimizer selection with an Ollama-hosted LLM.
 - [bbob-jax](https://github.com/bessagroup/bbob-jax) — JAX implementations of the BBOB and CEC 2005 black-box optimization benchmark functions.
 - [f3dasm](https://github.com/bessagroup/f3dasm) — Framework for Data-Driven Design and Analysis of Structures and Materials; provides `ExperimentData`, pipelines, and SLURM orchestration.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in the [bessagroup/f3dasm](https://github.com/bessagroup/f3dasm) GitHub Issues (managed via the `gh` CLI). External PRs are **not** a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical role names used verbatim — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, plus the repo's existing `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,57 @@
+# f3dasm
+
+The ubiquitous language of f3dasm — a framework for data-driven design and analysis of structures and materials. This file is a glossary, not a spec: it defines what each term *is*, free of implementation detail.
+
+## The data model
+
+**Domain**:
+The declared input/output parameter space of a problem.
+_Avoid_: search space, design space (when you mean the declared `Domain` object).
+
+**Parameter**:
+One named axis of a Domain — continuous, discrete, categorical, constant, or array-valued.
+_Avoid_: variable, feature, dimension.
+
+**ExperimentData**:
+The central collection of experiment samples that flows between blocks and is persistable to disk. The value type the whole framework passes around.
+_Avoid_: dataset, table, dataframe.
+
+**ExperimentSample**:
+A single row of ExperimentData: its input values, output values, and job status.
+_Avoid_: row, record, datapoint, trial.
+
+**Job status**:
+The lifecycle state of one ExperimentSample's evaluation: open → in progress → finished, or error.
+_Avoid_: state (alone), stage.
+
+## Computation
+
+**Block**:
+A unit of computation that transforms ExperimentData through one uniform call. Sampling, optimisation update steps, and transforms are all blocks; there is deliberately no separate class hierarchy beneath it.
+_Avoid_: operator, stage, transformer, task.
+
+**DataGenerator**:
+A per-sample evaluator — given an ExperimentSample's inputs it computes that sample's outputs. Drives the actual model/simulation evaluation.
+_Avoid_: function (alone), evaluator, simulator.
+
+**Parallelization mode**:
+The strategy by which a DataGenerator evaluates the samples in an ExperimentData — sequentially, in parallel, on a cluster, or as a cluster array. A property of *how* evaluation happens, not *what* is evaluated.
+_Avoid_: backend, strategy.
+
+## Execution
+
+**Pipeline**:
+An ordered, resumable workflow of steps.
+_Avoid_: workflow, DAG, job (alone).
+
+**Step**:
+One entry in a Pipeline: a block together with how it is run (its keyword arguments, whether it is parallel, where its data lives).
+_Avoid_: stage, node, task.
+
+**Executor**:
+The backend that runs a Pipeline in a particular environment — in the current process, or by submitting jobs to a SLURM cluster.
+_Avoid_: runner, scheduler, backend.
+
+**Execution context**:
+The description of *how and where* a single step is evaluated in a given environment — its parallelization mode and which jobs the current invocation is responsible for — independent of *what* the step computes. The same step runs locally or as one task of a SLURM array purely by changing its execution context.
+_Avoid_: config, options, environment (alone).

--- a/docs/adr/0001-executor-internal-step-dispatch.md
+++ b/docs/adr/0001-executor-internal-step-dispatch.md
@@ -1,0 +1,45 @@
+# Executor-internal step dispatch via a serializable execution context
+
+## Status
+
+accepted
+
+## Context
+
+Running one pipeline step — load `ExperimentData`, `arm` the block, branch on block
+type (`DataGenerator` / `Block` / callable), pick a parallelization mode, and persist
+the result — was implemented twice: once in `LocalExecutor._run_step_locally` and once
+in the SLURM worker's `_execute_step`. The two are near-identical and must be edited in
+lockstep, so they drift. The branches also disagreed in small ways (e.g. `result.store()`
+vs `result.store(run_dir)`), and `DataGenerator.call(mode=...)` carries an implicit,
+mode-dependent return-vs-persist contract that each executor re-derived — including a
+latent gap where `parallel_mode="parallel"` returns data that the local path never stored.
+
+## Decision
+
+Introduce one internal dispatcher, `run_step(step, run_dir, ctx)`, that both executors
+call. It owns the whole skeleton — the `from_file → arm` preamble, the block-type ladder,
+the array striding, and a single uniform persistence rule: `if result is not None:
+result.store(run_dir)` (the self-persisting cluster modes return `None` and are untouched).
+This also fixes the `parallel_mode="parallel"` persistence gap.
+
+The per-environment difference is carried by an **execution context** — a small,
+*serializable value* (parallelization mode, this invocation's job index, array size) with
+one `execute(block, data)` method. The local loop and the SLURM worker each construct one.
+
+The public seam `DataGenerator.call(mode=...)` is **not** changed; this work is confined to
+executor-internal code.
+
+## Considered options
+
+- **Abstract hooks on the `Executor` base** (each subclass overrides `run_datagenerator`,
+  etc.). Rejected: the SLURM worker is a *separate process* that unpickles only the
+  `Pipeline`/`Step` — it never has the `SlurmExecutor` instance, so a behavioural hook
+  object isn't available there. The variation must cross a cloudpickle/CLI boundary, which
+  forces a **value**, not a strategy object. This is the non-obvious constraint; do not
+  "simplify" the execution-context value back into methods on `Executor`.
+- **Redesigning `DataGenerator.call` to drop the `mode` string.** Rejected for now:
+  `DataGenerator` is public API; that would be a breaking change requiring a deprecation
+  path. Kept out of scope.
+- **Preserving the per-mode persistence special-casing bug-for-bug.** Rejected: it carries
+  the `parallel_mode="parallel"` non-persist gap forward into the freshly-deepened module.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,53 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+**Layout: single-context.** f3dasm is a single Python package (`src/f3dasm/`), so there is one `CONTEXT.md` + `docs/adr/` at the repo root — no `CONTEXT-MAP.md`.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-collapse-sampler-optimizer-into-block.md
+│   └── 0002-....md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root) — for reference; not used here:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in [bessagroup/f3dasm](https://github.com/bessagroup/f3dasm). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+**Repo note:** `wontfix` already exists in `bessagroup/f3dasm` and maps directly. The other four (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) are not yet defined as GitHub labels — `/triage` will create them on first use. If you later prefer to reuse adjacent existing labels (e.g. `question` for `needs-info`, `help wanted` for `ready-for-human`), edit the right-hand column instead.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/f3dasm/_src/experimentdata.py
+++ b/src/f3dasm/_src/experimentdata.py
@@ -1431,6 +1431,12 @@ class ExperimentData:
         This method loads ExperimentSample objects from JSON files in
         the EXPERIMENTSAMPLE_SUBFOLDER directory. If loading fails for
         any file, a warning is logged and the process continues.
+
+        Any disk-backed (``ReferenceValue``) inputs/outputs found on the
+        loaded samples are re-registered on the domain as ``to_disk``
+        parameters (see :meth:`_register_reference_parameters`) so a later
+        :meth:`store` / :meth:`from_file` round-trip preserves the reference
+        instead of flattening it to a bare path string.
         """
         d = self._copy(in_place=in_place)
 
@@ -1441,6 +1447,7 @@ class ExperimentData:
                 idx = int(json_file.stem)
                 es = ExperimentSample.from_json(json_file)
                 d.data[idx] = es
+                d._register_reference_parameters(es)
 
             except Exception as exc:
                 logger.warning(
@@ -1451,6 +1458,53 @@ class ExperimentData:
             return None
         else:
             return d
+
+    def _register_reference_parameters(
+        self, experiment_sample: ExperimentSample
+    ) -> None:
+        """Register a sample's on-disk parameters on the domain.
+
+        Samples loaded from array-job JSON files (see
+        :meth:`update_from_experimentssample_json`) carry
+        :class:`ReferenceValue` objects for any input or output stored on
+        disk, but the collecting :class:`ExperimentData`'s domain does not yet
+        know those parameters are disk-backed -- the outputs only came into
+        existence inside the (discarded) array-job process. This restores that
+        metadata (``to_disk=True`` plus the reference's ``load_function`` /
+        ``load_kwargs``) so that a subsequent :meth:`store` /
+        :meth:`from_file` round-trip keeps the reference. Without it, ``store``
+        would treat the value as an in-memory output, serialise the reference
+        as a bare path string, and reload it as a plain ``str`` instead of
+        loading the referenced object.
+
+        Parameters
+        ----------
+        experiment_sample : ExperimentSample
+            The sample whose ``ReferenceValue`` inputs/outputs are registered.
+        """
+        for name, value in experiment_sample._input_data.items():
+            if (
+                isinstance(value, ReferenceValue)
+                and name not in self.domain.input_space
+            ):
+                self.domain.add_parameter(
+                    name=name,
+                    to_disk=True,
+                    load_function=value.load_function,
+                    load_kwargs=value.load_kwargs,
+                )
+
+        for name, value in experiment_sample._output_data.items():
+            if (
+                isinstance(value, ReferenceValue)
+                and name not in self.domain.output_space
+            ):
+                self.domain.add_output(
+                    name=name,
+                    to_disk=True,
+                    load_function=value.load_function,
+                    load_kwargs=value.load_kwargs,
+                )
 
     def get_open_job(self) -> tuple[int, ExperimentSample, Domain]:
         """

--- a/src/f3dasm/_src/pipeline/executors/_runner.py
+++ b/src/f3dasm/_src/pipeline/executors/_runner.py
@@ -1,0 +1,129 @@
+"""Unified single-step dispatch shared by every executor.
+
+``run_step`` is the one place that knows how to run a pipeline
+:class:`~f3dasm._src.pipeline.pipeline.Step`: the ``from_file -> arm``
+preamble, the block-type ladder, and the single uniform persistence rule.
+
+The per-environment difference -- running a step locally versus running it as
+one task of a SLURM array -- is carried by an :class:`ExecutionContext`. That
+context is a small, serializable *value* (not a behaviour object) so it can
+cross the cloudpickle/CLI boundary into a fresh worker process, which never
+holds the submitting executor instance.
+"""
+
+#                                                                       Modules
+# =============================================================================
+
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+# Local
+from ...core import Block, DataGenerator
+from ...experimentdata import ExperimentData
+
+if TYPE_CHECKING:
+    from ..pipeline import Step
+
+#                                                          Authorship & Credits
+# =============================================================================
+__author__ = "Martin van der Schelling (M.P.vanderSchelling@tudelft.nl)"
+__credits__ = ["Martin van der Schelling"]
+__status__ = "Stable"
+# =============================================================================
+#
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ExecutionContext:
+    """How and where a single step is evaluated, independent of what it runs.
+
+    Parameters
+    ----------
+    mode : str
+        The parallelization mode passed to :meth:`DataGenerator.call` for a
+        single (non-array) invocation. One of ``"sequential"``,
+        ``"parallel"``, or ``"cluster"``.
+    job_number : int | None
+        For a SLURM array task, the array-task index this invocation owns;
+        ``None`` for a single local or whole-cluster invocation.
+    max_array_size : int | None
+        For a SLURM array task, the array width used to stride the open jobs
+        across tasks. Unused when ``job_number`` is ``None``.
+    """
+
+    mode: str
+    job_number: int | None = None
+    max_array_size: int | None = None
+
+    def execute(
+        self,
+        block: DataGenerator,
+        data: ExperimentData,
+        kwargs: dict,
+    ) -> ExperimentData | None:
+        """Run ``block`` over ``data`` according to this context.
+
+        Returns
+        -------
+        ExperimentData | None
+            The in-memory ExperimentData for return-and-store modes
+            (``sequential``, ``parallel``); ``None`` for the self-persisting
+            cluster modes, which write their results to disk directly.
+        """
+        if self.job_number is None:
+            return block.call(data=data, mode=self.mode, **kwargs)
+
+        # SLURM array task: own only the strided slice of the open jobs and
+        # run each as a self-persisting ``cluster_array`` evaluation.
+        open_jobs = data.select_with_status("open").index.tolist()
+        for idx in open_jobs[self.job_number :: self.max_array_size]:
+            block.call(
+                data=data,
+                mode="cluster_array",
+                job_number=idx,
+                **kwargs,
+            )
+        return None
+
+
+def run_step(step: Step, run_dir: Path, ctx: ExecutionContext) -> None:
+    """Execute a single pipeline step against the data in ``run_dir``.
+
+    Parameters
+    ----------
+    step : Step
+        The pipeline step to execute (its block, kwargs, and parallel flag).
+    run_dir : Path
+        The project run directory on disk holding the step's ExperimentData.
+    ctx : ExecutionContext
+        How and where to evaluate the step in the current environment.
+
+    Raises
+    ------
+    TypeError
+        If the step's block is neither a DataGenerator, a Block, nor callable.
+    """
+    block = step.block
+
+    if isinstance(block, DataGenerator):
+        data: ExperimentData = ExperimentData.from_file(project_dir=run_dir)
+        block.arm(data)
+        result = ctx.execute(block, data, step.kwargs)
+        if result is not None:
+            result.store(run_dir)
+    elif isinstance(block, Block):
+        data = ExperimentData.from_file(project_dir=run_dir)
+        block.arm(data)
+        result = block.call(data=data, **step.kwargs)
+        result.store(run_dir)
+    elif callable(block):
+        block(project_dir=run_dir, **step.kwargs)
+    else:
+        raise TypeError(
+            f"Step {step.name!r} has an unsupported block type: {type(block)}"
+        )

--- a/src/f3dasm/_src/pipeline/executors/local.py
+++ b/src/f3dasm/_src/pipeline/executors/local.py
@@ -12,9 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 # Local
-from ...core import Block, DataGenerator
-from ...experimentdata import ExperimentData
 from ..pipeline import Pipeline, Step
+from ._runner import ExecutionContext, run_step
 from .base import Executor
 
 #                                                          Authorship & Credits
@@ -112,17 +111,10 @@ def _run_step_locally(
 ) -> None:
     """Execute a single pipeline step in the local process.
 
-    Dispatches to the appropriate execution strategy based on the
-    block type:
-
-    - **DataGenerator** with ``parallel=True``: uses
-      ``parallel_mode`` (default ``"cluster"``).
-    - **DataGenerator** without ``parallel``: uses ``"cluster"``
-      mode (single job at a time, in-process).
-    - **Block**: loads ExperimentData from disk, calls
-      ``arm`` + ``call``, and stores the result back.
-    - **callable**: invokes with ``project_dir`` and
-      ``project_job``.
+    Builds the local :class:`ExecutionContext` and delegates to the shared
+    :func:`run_step` dispatcher. A parallel :class:`DataGenerator` step uses
+    ``parallel_mode`` (default ``"cluster"``); every other step uses
+    ``"cluster"`` -- the mode is only consulted for DataGenerator steps.
 
     Parameters
     ----------
@@ -131,33 +123,7 @@ def _run_step_locally(
     run_dir : Path
         The project run directory on disk.
     parallel_mode : str
-        Mode for DataGenerator parallel steps.
+        Mode for parallel DataGenerator steps. Defaults to ``"cluster"``.
     """
-    block = step.block
-
-    if isinstance(block, DataGenerator):
-        # Load ExperimentData from disk and run the DataGenerator.
-        data: ExperimentData = ExperimentData.from_file(project_dir=run_dir)
-        block.arm(data)
-        mode: str = parallel_mode if step.parallel else "cluster"
-        result: ExperimentData | None = block.call(
-            data=data, mode=mode, **step.kwargs
-        )
-        if mode == "sequential":
-            result.store()
-    elif isinstance(block, Block):
-        # Load ExperimentData from disk, run arm + call, persist.
-        data = ExperimentData.from_file(project_dir=run_dir)
-        block.arm(data)
-        result = block.call(data=data, **step.kwargs)
-        result.store()
-    elif callable(block):
-        # Plain callable (e.g. the first step that creates
-        # ExperimentData from scratch). It receives the run
-        # directory and is responsible for creating and storing
-        # data on disk.
-        block(project_dir=run_dir, **step.kwargs)
-    else:
-        raise TypeError(
-            f"Step {step.name!r} has an unsupported block type: {type(block)}"
-        )
+    mode = parallel_mode if step.parallel else "cluster"
+    run_step(step=step, run_dir=run_dir, ctx=ExecutionContext(mode=mode))

--- a/src/f3dasm/_src/pipeline/run_step.py
+++ b/src/f3dasm/_src/pipeline/run_step.py
@@ -39,8 +39,7 @@ from pathlib import Path
 import cloudpickle
 
 # Local
-from ..core import Block, DataGenerator
-from ..experimentdata import ExperimentData
+from .executors._runner import ExecutionContext, run_step
 from .loop import Loop
 from .pipeline import Pipeline, Step
 
@@ -207,17 +206,16 @@ def _execute_step(
 ) -> None:
     """Execute a single step's block on a cluster node.
 
-    This function is called from within a SLURM job. The
-    dispatch logic differs from local execution:
+    This function is called from within a SLURM job. It builds the cluster
+    :class:`ExecutionContext` and delegates to the shared :func:`run_step`
+    dispatcher:
 
-    - **Parallel DataGenerator** (``job_number`` is set): uses
-      ``"cluster_array"`` mode so each array task processes one
-      job index.
-    - **Non-parallel DataGenerator**: uses ``"cluster"`` mode
-      with file-lock coordination for multi-node execution.
-    - **Block**: loads ExperimentData, runs ``arm`` + ``call``,
-      and stores the result back to disk.
-    - **callable**: invokes with project context.
+    - **Parallel DataGenerator** with a SLURM array task id: runs as a
+      ``cluster_array`` task owning the strided slice
+      ``open[job_number::max_array_size]`` of the open jobs.
+    - **Every other step** (non-parallel DataGenerator, Block, callable):
+      runs in ``"cluster"`` mode with file-lock coordination for multi-node
+      execution.
 
     Parameters
     ----------
@@ -229,46 +227,16 @@ def _execute_step(
     job_number : int | None
         SLURM array task ID, or ``None`` for non-array jobs.
     """
-    block = step.block
-
-    if isinstance(block, DataGenerator):
-        # Load ExperimentData from disk before dispatching.
-        data: ExperimentData = ExperimentData.from_file(project_dir=run_dir)
-        block.arm(data)
-        if step.parallel and job_number is not None:
-            # Array job: each SLURM task processes one job index.
-            # The DataGenerator handles the strided access pattern
-            # internally (job_number::max_array_size).
-            max_array_size = step.resources.max_array_size
-            open_experiments = data.select_with_status("open").index.tolist()
-
-            job_numbers = open_experiments[job_number::max_array_size]
-
-            for job_idx in job_numbers:
-                _ = block.call(
-                    data=data,
-                    mode="cluster_array",
-                    job_number=job_idx,
-                    **step.kwargs,
-                )
-        else:
-            # Non-parallel DataGenerator on cluster: use file-lock
-            # coordination so multiple nodes can safely share the
-            # same ExperimentData on disk.
-            block.call(data=data, mode="cluster", **step.kwargs)
-    elif isinstance(block, Block):
-        # Single-node Block execution: load data, transform,
-        # persist.
-        data: ExperimentData = ExperimentData.from_file(project_dir=run_dir)
-        block.arm(data)
-        result: ExperimentData = block.call(data=data, **step.kwargs)
-        result.store(run_dir)
-    elif callable(block):
-        block(project_dir=run_dir, **step.kwargs)
-    else:
-        raise TypeError(
-            f"Step {step.name!r} has an unsupported block type: {type(block)}"
+    if step.parallel and job_number is not None:
+        ctx = ExecutionContext(
+            mode="cluster_array",
+            job_number=job_number,
+            max_array_size=step.resources.max_array_size,
         )
+    else:
+        ctx = ExecutionContext(mode="cluster")
+
+    run_step(step=step, run_dir=run_dir, ctx=ctx)
 
 
 if __name__ == "__main__":

--- a/tests/pipeline/test_blocks.py
+++ b/tests/pipeline/test_blocks.py
@@ -76,3 +76,53 @@ class TestCollectArrayResults:
         # Should not raise even without experiment_sample dir
         result = block.call(data=data)
         assert result is not None
+
+    def test_disk_backed_output_survives_collect_store_reload(self, tmp_path):
+        """A disk-backed (ReferenceValue) output must round-trip.
+
+        Regression test: the SLURM-array collection path used to drop the
+        domain's ``to_disk`` metadata, so after
+        ``CollectArrayResults`` -> ``store`` -> ``from_file`` a disk-backed
+        output (e.g. an array) reloaded as the bare reference *string*
+        (``'disp/0.npy'``) instead of the loaded object -- which then blew up
+        downstream (``float / str``) when a consumer indexed into it.
+        """
+        import numpy as np
+        import pandas as pd
+
+        from f3dasm._src.experimentdata import _store
+
+        domain = Domain()
+        domain.add_float("x", 0.0, 1.0)
+        data = ExperimentData(
+            domain=domain, input_data=pd.DataFrame({"x": [0.1, 0.2]})
+        )
+        data.store(project_dir=tmp_path)
+
+        # Emulate two SLURM array jobs, each producing an on-disk array output
+        # and persisting itself as an experiment_sample JSON file.
+        for idx in range(2):
+            d = ExperimentData.from_file(tmp_path)
+            sample = d.get_experiment_sample(idx)
+            sample.store_as_json(idx=idx)
+            sample.store(
+                object=np.array([1.0, 2.0, 3.0]), name="disp", to_disk=True
+            )
+            sample, d.domain = _store(
+                experiment_sample=sample, idx=idx, domain=d.domain
+            )
+            sample.mark("finished")
+            sample.store_as_json(idx=idx)
+
+        # reset step: collect the array results, then persist.
+        collected = CollectArrayResults(cleanup=True).call(
+            data=ExperimentData.from_file(tmp_path)
+        )
+        assert collected.domain.output_space["disp"].to_disk is True
+        collected.store(project_dir=tmp_path)
+
+        # downstream step: reload and read the output back.
+        reloaded = ExperimentData.from_file(tmp_path)
+        value = reloaded.get_experiment_sample(0).to_dict()["disp"]
+        assert isinstance(value, np.ndarray)
+        np.testing.assert_array_equal(value, np.array([1.0, 2.0, 3.0]))

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -1,0 +1,148 @@
+"""Tests for the unified step runner (run_step + ExecutionContext)."""
+
+import pytest
+
+from f3dasm import ExperimentData, create_sampler, datagenerator
+from f3dasm._src.pipeline.executors._runner import (
+    ExecutionContext,
+    run_step,
+)
+from f3dasm._src.pipeline.pipeline import Step
+from f3dasm.design import Domain
+
+pytestmark = pytest.mark.smoke
+
+
+@datagenerator(output_names="y")
+def _parallel_const(x):
+    """Module-level generator so multiprocessing can pickle it."""
+    return 7.0
+
+
+def _stored_open_data(tmp_path, n_samples=3):
+    """Store an ExperimentData with `n_samples` open jobs to disk."""
+    domain = Domain()
+    domain.add_float("x", 0.0, 1.0)
+    domain.add_output("y")
+    data = ExperimentData(domain=domain)
+    sampler = create_sampler("random", seed=42)
+    data = sampler.call(data=data, n_samples=n_samples)
+    data.store(project_dir=tmp_path)
+    return data
+
+
+class TestRunStepSequential:
+    def test_sequential_datagenerator_persists_outputs(self, tmp_path):
+        @datagenerator(output_names="y")
+        def const(x):
+            return 42.0
+
+        _stored_open_data(tmp_path, n_samples=3)
+        step = Step(block=const, name="gen")
+
+        run_step(
+            step=step,
+            run_dir=tmp_path,
+            ctx=ExecutionContext(mode="sequential"),
+        )
+
+        reloaded = ExperimentData.from_file(project_dir=tmp_path)
+        ys = [
+            reloaded.get_experiment_sample(i).output_data["y"]
+            for i in range(3)
+        ]
+        assert ys == [42.0, 42.0, 42.0]
+
+
+class TestRunStepBlock:
+    def test_block_result_is_persisted(self, tmp_path):
+        from f3dasm._src.core import Block
+
+        class MarkAllFinished(Block):
+            def call(self, data, **kwargs):
+                return data.mark_all("finished")
+
+        _stored_open_data(tmp_path, n_samples=3)
+        step = Step(block=MarkAllFinished(), name="mark")
+
+        run_step(
+            step=step,
+            run_dir=tmp_path,
+            ctx=ExecutionContext(mode="sequential"),
+        )
+
+        reloaded = ExperimentData.from_file(project_dir=tmp_path)
+        assert len(reloaded.select_with_status("open")) == 0
+
+
+class TestRunStepCallable:
+    def test_callable_invoked_with_project_dir_and_kwargs(self, tmp_path):
+        received = {}
+
+        def make(project_dir, **kwargs):
+            received["project_dir"] = str(project_dir)
+            received["kwargs"] = dict(kwargs)
+
+        step = Step(block=make, name="create", kwargs={"n": 5})
+
+        run_step(
+            step=step,
+            run_dir=tmp_path,
+            ctx=ExecutionContext(mode="sequential"),
+        )
+
+        assert received["project_dir"] == str(tmp_path)
+        assert received["kwargs"] == {"n": 5}
+
+    def test_unsupported_block_type_raises(self, tmp_path):
+        step = Step(block=42, name="bad")
+        with pytest.raises(TypeError, match="unsupported block type"):
+            run_step(
+                step=step,
+                run_dir=tmp_path,
+                ctx=ExecutionContext(mode="sequential"),
+            )
+
+
+class TestRunStepArrayStriding:
+    def test_array_task_processes_strided_subset(self, tmp_path):
+        @datagenerator(output_names="y")
+        def const(x):
+            return 1.0
+
+        _stored_open_data(tmp_path, n_samples=4)
+        step = Step(block=const, name="gen", parallel=True)
+
+        # Array task 0 of width 2 owns the strided open indices [0, 2].
+        run_step(
+            step=step,
+            run_dir=tmp_path,
+            ctx=ExecutionContext(
+                mode="cluster_array", job_number=0, max_array_size=2
+            ),
+        )
+
+        sample_dir = tmp_path / "experiment_sample"
+        written = sorted(p.stem for p in sample_dir.glob("*.json"))
+        assert written == ["0", "2"]
+
+
+class TestParallelModePersistRegression:
+    """parallel_mode='parallel' must persist its results (was a latent gap)."""
+
+    def test_parallel_mode_persists_results(self, tmp_path):
+        from f3dasm._src.pipeline.executors.local import _run_step_locally
+
+        _stored_open_data(tmp_path, n_samples=2)
+        step = Step(block=_parallel_const, name="gen", parallel=True)
+
+        _run_step_locally(
+            step=step, run_dir=tmp_path, parallel_mode="parallel"
+        )
+
+        reloaded = ExperimentData.from_file(project_dir=tmp_path)
+        ys = [
+            reloaded.get_experiment_sample(i).output_data["y"]
+            for i in range(2)
+        ]
+        assert ys == [7.0, 7.0]


### PR DESCRIPTION
## What

`LocalExecutor._run_step_locally` and the SLURM worker's `_execute_step` duplicated the same step-dispatch ladder — `load → arm → branch on block type → pick mode → persist`. The two had to be edited in lockstep, drifted, and disagreed on persistence.

This extracts one internal dispatcher and a small value object, and routes both executors through it:

- **`run_step(step, run_dir, ctx)`** (`executors/_runner.py`) — the single place that owns the `isinstance` ladder, the `from_file → arm` preamble, and one uniform persistence rule: `if result is not None: result.store(run_dir)`.
- **`ExecutionContext`** — a small, serializable value (mode + array job-selection) that each environment constructs. It's a *value*, not a behaviour hook, deliberately: the SLURM worker is a separate process that unpickles only the `Pipeline`/`Step` and never holds the `SlurmExecutor` instance, so the variation has to cross the cloudpickle/CLI boundary.

`_run_step_locally` and `_execute_step` collapse to thin context-builders (**+41 / −93** lines across the two production files).

## Behaviour change

Exactly one: `parallel_mode="parallel"` now **persists** its results. Previously `evaluate_multiprocessing` returned data that the local path only stored when `mode == "sequential"`, so parallel results were silently dropped. Covered by a regression test. Everything else is byte-identical.

The public `DataGenerator.call(mode=...)` interface is **unchanged** — this work is confined to executor-internal code, so no notebook/mkdocs-nav updates are needed.

## Why a value, not Executor hooks

Recorded in `docs/adr/0001-executor-internal-step-dispatch.md`, including the rejected OO-hook alternative — so nobody "simplifies" the context value back into methods on `Executor` and breaks SLURM.

## Tests

New `tests/pipeline/test_runner.py` (6 tests, built test-first): sequential persists, Block persists, callable + unsupported-type, **SLURM array striding verified without a cluster**, and the `parallel_mode="parallel"` regression.

- `ruff check` + `ruff format` clean
- smoke suite: 1093 passed · full suite: **1096 passed**, coverage **91.03%** (gate 85%)

## Also included: SLURM array-collection disk-reference fix

While driving a real parallel pipeline (an ABAQUS lin-buckle → Riks study) through the SLURM array path, a disk-backed output (`np.ndarray`) reloaded in the downstream step as the **bare reference string** (`'max_disps/0.npy'`) rather than the array, blowing up as `unsupported operand type(s) for /: 'float' and 'str'` when a consumer indexed into it.

Root cause: `ExperimentData.update_from_experimentssample_json` (what `CollectArrayResults` calls) rebuilt each collected sample from its array-job JSON with the correct `ReferenceValue` inputs/outputs, but never re-registered those parameters on the domain. After collection `domain.output_space` was empty, so the next `store()` inferred the outputs as `to_disk=False`, serialised each `ReferenceValue` as a bare path string, and `from_file` reloaded a plain `str`.

Fix: re-register any `ReferenceValue`-typed inputs/outputs of collected samples on the domain as `to_disk=True` (carrying the reference's `load_function` / `load_kwargs`) via a new `_register_reference_parameters` helper, so a later `store()` / `from_file()` round-trip preserves the reference. This affects any parallel pipeline that stores array/disk-backed outputs across an array step.

New regression test `tests/pipeline/test_blocks.py::TestCollectArrayResults::test_disk_backed_output_survives_collect_store_reload` — fails without the fix (the collected domain lacks the disk output), passes with it. `experimentdata` + `pipeline` + `design` suites green; `ruff` clean.

## Also included

A commit scaffolds the engineering-skills config (`docs/agents/*`, the `CLAUDE.md` "Agent skills" section) and `CONTEXT.md` — the project's first domain glossary — from the same working session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
