### PR TITLE
Expose EmptyFileError and ReachMaximumTriesError in the public API

### DIFF
--- a/src/f3dasm/__init__.py
+++ b/src/f3dasm/__init__.py
@@ -21,6 +21,7 @@ from ._src.core import (
     datagenerator,
 )
 from ._src.datageneration.datagenerator_factory import create_datagenerator
+from ._src.errors import EmptyFileError, ReachMaximumTriesError
 from ._src.experimentdata import ExperimentData
 from ._src.experimentsample import ExperimentSample
 from ._src.optimization.optimizer_factory import create_optimizer
@@ -47,11 +48,13 @@ __all__ = [
     "ChainedBlock",
     "CollectArrayResults",
     "DataGenerator",
+    "EmptyFileError",
     "ExperimentData",
     "ExperimentSample",
     "Loop",
     "LoopBlock",
     "Pipeline",
+    "ReachMaximumTriesError",
     "SlurmCluster",
     "SlurmResources",
     "Step",


### PR DESCRIPTION
`EmptyFileError` and `ReachMaximumTriesError` are raised by public methods
(`ExperimentData.from_file` and the domain/data loading paths), but they can
only be imported from `f3dasm._src.errors`. Code that uses the public API
cannot catch what that API throws without reaching into the private `_src`
module.

This re-exports both at the top level, the same way the other user-facing
classes are exposed:

```python
from f3dasm import EmptyFileError, ReachMaximumTriesError
```

Re-export only. No behavior change and no new dependencies.
