### PR TITLE
fix: per-CPU memory accounting and --ntasks in SLURM executor (#352)

### DIFF
--- a/docs/adr/0003-per-cpu-memory-accounting.md
+++ b/docs/adr/0003-per-cpu-memory-accounting.md
@@ -1,0 +1,94 @@
+# Per-CPU memory accounting in rendered sbatch scripts
+
+## Status
+
+accepted
+
+## Context
+
+Both script renderers (`render_sbatch_script`, `render_orchestrator_script`)
+built a fixed `#SBATCH` header that always emitted per-node `--mem` and `--nodes`
+and *never* emitted `--ntasks`. On any SLURM site whose `job_submit` filter
+mandates a task count and per-CPU memory accounting — notably TU Delft's
+DelftBlue — the very first `sbatch` (the orchestrator, and equally every step)
+is rejected at submission time:
+
+```
+error: This job submission doesn't specify the number of tasks. Specify '--ntasks=<ntasks>'.
+error: This job submission doesn't specify the amount of memory per-cpu (or per-gpu). Specify '--mem-per-cpu=<mem>'.
+```
+
+so a `SlurmCluster` pipeline could not run there at all — no partial degradation,
+nothing submits. Crucially there was **no config-only workaround**:
+`SlurmResources.extra_sbatch` can add `--mem-per-cpu`, but the hard-coded `--mem`
+line is still emitted alongside it, and SLURM treats `--mem` together with
+`--mem-per-cpu` as a **fatal** error (`--mem, --mem-per-cpu, and --mem-per-gpu
+are mutually exclusive`), not a warning — on *every* site, not just DelftBlue.
+This mutual exclusivity is what makes `extra_sbatch` structurally insufficient:
+the fix has to be able to *omit* `--mem`, which only the renderer can do.
+
+Cross-checked against Brown's Oscar (plain SLURM, no per-CPU mandate): the flags
+emitted before this change (`--mem=8G --nodes=1`, no `--ntasks`) submit cleanly
+there, and `--mem` + `--mem-per-cpu` together fail there too — confirming the
+constraint is general SLURM behaviour, not a DelftBlue quirk, and that Oscar must
+not regress.
+
+## Decision
+
+`SlurmResources` gains two fields, `ntasks: int = 1` and
+`mem_per_cpu: str | None = None`, and both renderers share one
+`_render_resource_directives(res)` helper (so the two headers cannot drift) that:
+
+- **Emits `--ntasks={res.ntasks}` unconditionally, on every cluster.** This is a
+  deliberate choice, not an oversight: `--ntasks=1` was confirmed harmless on
+  Oscar (a plain-SLURM site) and a single always-present field is simpler than a
+  second implicit on/off switch keyed off `mem_per_cpu`.
+- **Chooses the memory directive by `mem_per_cpu`:** when it is set, emit
+  `--mem-per-cpu={res.mem_per_cpu}` and **omit `--mem` entirely**; otherwise emit
+  the per-node `--mem={res.mem}` (unchanged). When `mem_per_cpu` is set, `mem` is
+  ignored.
+- **Omits `--nodes` only when `mem_per_cpu` is set *and* `nodes == 1`** (its
+  default): per-task allocation makes it redundant and it silences DelftBlue's
+  benign "`--nodes` without `--exclusive`" warning. An explicit `nodes > 1` is
+  always emitted — an explicit multi-node request is never silently dropped.
+
+`mem`/`mem_per_cpu` precedence is **documented, not validated**: a dataclass
+cannot distinguish "user left `mem` at its default" from "user set `mem` to that
+same value," so any `__post_init__` "both set" guard would false-positive. Site
+*values* (keeping `cpus_per_task × mem_per_cpu` under a partition's
+`MaxMemPerCPU`) remain the caller's responsibility; f3dasm only makes the per-CPU
+model *expressible*.
+
+Backward compatibility: `mem_per_cpu` defaults to `None`, so per-node `--mem`
+output is unchanged wherever it is not opted into. The only behaviour change for
+existing configs is the added `--ntasks=1` line (confirmed harmless on both
+DelftBlue and Oscar). All six golden fixtures under `tests/pipeline/golden/*.sh`
+gain that one line and were regenerated accordingly.
+
+### Consequence: the orchestrator's default resources
+
+`_DEFAULT_ORCH_RESOURCES` (in `slurm.py`) keeps `mem="1G"` with
+`mem_per_cpu=None`, so a DelftBlue pipeline that does **not** override
+`Pipeline.orchestrator_resources` will still render `--mem=1G` for the
+orchestrator job and be rejected. To run end-to-end on a per-CPU site the caller
+must set `orchestrator_resources=SlurmResources(mem_per_cpu=..., ...)` as well as
+per-step resources. This is intentional: baking a DelftBlue-specific value into
+the framework default is exactly the site-specific concern this change leaves to
+the caller — the default deliberately stays per-node.
+
+## Considered options
+
+- **Gating `--ntasks` behind `mem_per_cpu`.** Rejected: it makes the header
+  depend on a second implicit switch for no benefit, since `--ntasks=1` is
+  harmless where it is not required. One always-present field is simpler.
+- **A `__post_init__` guard rejecting "both `mem` and `mem_per_cpu` set."**
+  Rejected: dataclass defaults make "explicitly set to the default" and "left at
+  the default" indistinguishable, so the check would false-positive on
+  legitimate configs. Precedence is documented instead.
+- **Fixing it in `extra_sbatch` / leaving the header alone.** Rejected: `--mem`
+  and `--mem-per-cpu` are mutually exclusive (fatal) at every SLURM site, so the
+  hard-coded `--mem` must be *omittable* — a config appended *after* the fixed
+  header cannot achieve that.
+- **Validating `mem_per_cpu` against a partition's `MaxMemPerCPU`.** Rejected as
+  out of scope: f3dasm cannot know per-partition caps, and this stays a
+  site/caller concern (mirrors the resource-value stance of ADR 0002).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ maintainers = [
 name = "f3dasm"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.3.0"
+version = "2.4.0"
 
 [project.optional-dependencies]
 all = [

--- a/src/f3dasm/_src/pipeline/executors/slurm.py
+++ b/src/f3dasm/_src/pipeline/executors/slurm.py
@@ -298,6 +298,48 @@ class SlurmExecutor(Executor):
 # =============================================================================
 
 
+def _render_resource_directives(res: SlurmResources) -> list[str]:
+    """Render the resource ``#SBATCH`` directives common to both renderers.
+
+    Emits ``--time``, the memory directive, ``--ntasks``,
+    ``--cpus-per-task`` and (conditionally) ``--nodes`` -- the block
+    shared verbatim by :func:`render_sbatch_script` and
+    :func:`render_orchestrator_script`, kept in one place so the two
+    headers cannot drift.
+
+    The memory directive is ``--mem-per-cpu`` when ``res.mem_per_cpu``
+    is set and the per-node ``--mem`` otherwise; SLURM treats the two
+    as mutually exclusive, so exactly one is emitted. ``--ntasks`` is
+    always emitted (sites with a ``job_submit`` filter that mandates a
+    task count reject jobs without it; it is harmless elsewhere).
+    ``--nodes`` is omitted when ``mem_per_cpu`` is set *and* ``nodes``
+    is at its default of ``1`` -- per-task allocation makes it
+    redundant and it silences the benign "``--nodes`` without
+    ``--exclusive``" warning; an explicit ``nodes > 1`` is always
+    emitted.
+
+    Parameters
+    ----------
+    res : SlurmResources
+        The resources describing this job.
+
+    Returns
+    -------
+    list[str]
+        The rendered ``#SBATCH`` directive lines, in header order.
+    """
+    directives = [f"#SBATCH --time={res.time}"]
+    if res.mem_per_cpu is not None:
+        directives.append(f"#SBATCH --mem-per-cpu={res.mem_per_cpu}")
+    else:
+        directives.append(f"#SBATCH --mem={res.mem}")
+    directives.append(f"#SBATCH --ntasks={res.ntasks}")
+    directives.append(f"#SBATCH --cpus-per-task={res.cpus_per_task}")
+    if not (res.mem_per_cpu is not None and res.nodes == 1):
+        directives.append(f"#SBATCH --nodes={res.nodes}")
+    return directives
+
+
 def render_sbatch_script(
     step: Step,
     cluster: SlurmCluster,
@@ -354,10 +396,7 @@ def render_sbatch_script(
     lines: list[str] = [
         "#!/bin/bash",
         f"#SBATCH --job-name={label}_{pipeline_name}",
-        f"#SBATCH --time={res.time}",
-        f"#SBATCH --mem={res.mem}",
-        f"#SBATCH --cpus-per-task={res.cpus_per_task}",
-        f"#SBATCH --nodes={res.nodes}",
+        *_render_resource_directives(res),
         f"#SBATCH --partition={cluster.partition}",
         f"#SBATCH --account={cluster.account}",
     ]
@@ -509,10 +548,7 @@ def render_orchestrator_script(
     lines: list[str] = [
         "#!/bin/bash",
         f"#SBATCH --job-name=orchestrator_{pipeline.name}",
-        f"#SBATCH --time={res.time}",
-        f"#SBATCH --mem={res.mem}",
-        f"#SBATCH --cpus-per-task={res.cpus_per_task}",
-        f"#SBATCH --nodes={res.nodes}",
+        *_render_resource_directives(res),
         f"#SBATCH --partition={cluster.partition}",
         f"#SBATCH --account={cluster.account}",
         f"#SBATCH --output={log_dir_path}/orchestrator_%j.out",

--- a/src/f3dasm/_src/pipeline/resources.py
+++ b/src/f3dasm/_src/pipeline/resources.py
@@ -31,11 +31,16 @@ class SlurmResources:
     time : str
         Wall-clock time limit (e.g. ``"01:00:00"``).
     mem : str
-        Memory per node (e.g. ``"4G"``).
+        Memory per node (e.g. ``"4G"``). Ignored when
+        ``mem_per_cpu`` is set (see ``mem_per_cpu``).
     cpus_per_task : int
         Number of CPUs per task.
     nodes : int
-        Number of nodes.
+        Number of nodes. When ``mem_per_cpu`` is set and ``nodes``
+        is left at its default of ``1``, the ``--nodes`` directive
+        is omitted from the rendered script (per-task allocation
+        makes it redundant); an explicit ``nodes > 1`` is always
+        emitted.
     max_array_size : int
         Maximum SLURM array size (capped by cluster policy).
     max_concurrent : int
@@ -55,6 +60,22 @@ class SlurmResources:
     extra_sbatch : dict[str, str]
         Arbitrary extra ``#SBATCH`` directives as key-value
         pairs.
+    ntasks : int
+        Number of tasks (``--ntasks``). Always emitted, on every
+        cluster. Sites whose ``job_submit`` filter mandates a task
+        count (e.g. TU Delft's DelftBlue) reject jobs that omit it;
+        ``--ntasks=1`` is harmless where it is not required.
+    mem_per_cpu : str | None
+        Per-CPU memory (e.g. ``"3968M"``). When set, the rendered
+        script emits ``--mem-per-cpu`` instead of ``--mem`` (the two
+        are mutually exclusive in SLURM) and ``mem`` is ignored.
+        Required by sites enforcing per-CPU memory accounting.
+        Defaults to ``None`` (per-node ``--mem`` is used). The
+        precedence over ``mem`` is documented, not validated: a
+        dataclass cannot tell an explicitly-set ``mem`` from its
+        default, so no runtime "both set" check is attempted. Keep
+        ``cpus_per_task * mem_per_cpu`` under the partition's
+        ``MaxMemPerCPU`` cap — that remains the caller's concern.
     """
 
     time: str = "01:00:00"
@@ -65,6 +86,8 @@ class SlurmResources:
     max_concurrent: int = 64
     max_jobs_per_task: int | None = 1
     extra_sbatch: dict[str, str] = field(default_factory=dict)
+    ntasks: int = 1
+    mem_per_cpu: str | None = None
 
     def __post_init__(self) -> None:
         if self.max_jobs_per_task is not None and self.max_jobs_per_task < 1:

--- a/tests/pipeline/golden/collect.sh
+++ b/tests/pipeline/golden/collect.sh
@@ -2,6 +2,7 @@
 #SBATCH --job-name=collect_golden
 #SBATCH --time=01:00:00
 #SBATCH --mem=4G
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --nodes=1
 #SBATCH --partition=compute

--- a/tests/pipeline/golden/evaluate.sh
+++ b/tests/pipeline/golden/evaluate.sh
@@ -2,6 +2,7 @@
 #SBATCH --job-name=evaluate_golden
 #SBATCH --time=02:00:00
 #SBATCH --mem=8G
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=4
 #SBATCH --nodes=1
 #SBATCH --partition=compute

--- a/tests/pipeline/golden/loop2_run.sh
+++ b/tests/pipeline/golden/loop2_run.sh
@@ -2,6 +2,7 @@
 #SBATCH --job-name=loop2_run_golden
 #SBATCH --time=02:00:00
 #SBATCH --mem=8G
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=4
 #SBATCH --nodes=1
 #SBATCH --partition=compute

--- a/tests/pipeline/golden/loop2_sample.sh
+++ b/tests/pipeline/golden/loop2_sample.sh
@@ -2,6 +2,7 @@
 #SBATCH --job-name=loop2_sample_golden
 #SBATCH --time=01:00:00
 #SBATCH --mem=4G
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --nodes=1
 #SBATCH --partition=compute

--- a/tests/pipeline/golden/make.sh
+++ b/tests/pipeline/golden/make.sh
@@ -2,6 +2,7 @@
 #SBATCH --job-name=make_golden
 #SBATCH --time=01:00:00
 #SBATCH --mem=4G
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --nodes=1
 #SBATCH --partition=compute

--- a/tests/pipeline/golden/orchestrator.sh
+++ b/tests/pipeline/golden/orchestrator.sh
@@ -2,6 +2,7 @@
 #SBATCH --job-name=orchestrator_golden
 #SBATCH --time=00:10:00
 #SBATCH --mem=1G
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --nodes=1
 #SBATCH --partition=compute

--- a/tests/pipeline/test_resources.py
+++ b/tests/pipeline/test_resources.py
@@ -19,6 +19,8 @@ class TestSlurmResources:
         assert r.max_concurrent == 64
         assert r.max_jobs_per_task == 1
         assert r.extra_sbatch == {}
+        assert r.ntasks == 1
+        assert r.mem_per_cpu is None
 
     def test_custom_values(self):
         r = SlurmResources(
@@ -29,12 +31,16 @@ class TestSlurmResources:
             max_array_size=500,
             max_concurrent=32,
             extra_sbatch={"gres": "gpu:1"},
+            ntasks=4,
+            mem_per_cpu="3968M",
         )
         assert r.time == "02:00:00"
         assert r.mem == "16G"
         assert r.cpus_per_task == 4
         assert r.nodes == 2
         assert r.extra_sbatch == {"gres": "gpu:1"}
+        assert r.ntasks == 4
+        assert r.mem_per_cpu == "3968M"
 
     @pytest.mark.parametrize("value", [None, 1, 2, 10])
     def test_max_jobs_per_task_valid(self, value):

--- a/tests/pipeline/test_slurm.py
+++ b/tests/pipeline/test_slurm.py
@@ -58,7 +58,10 @@ class TestRenderSbatchScript:
         assert "#SBATCH --job-name=train_my_pipe" in script
         assert "#SBATCH --time=01:00:00" in script
         assert "#SBATCH --mem=4G" in script
+        # --ntasks is always emitted (default 1), before --cpus-per-task.
+        assert "#SBATCH --ntasks=1" in script
         assert "#SBATCH --cpus-per-task=2" in script
+        assert "#SBATCH --nodes=1" in script
         assert "#SBATCH --partition=compute" in script
         assert "#SBATCH --account=proj123" in script
         assert "#SBATCH --gres=gpu:1" in script
@@ -676,3 +679,86 @@ class TestSysPathSerialization:
 
         paths = json.loads((tmp_path / "myjob" / ".sys_path.json").read_text())
         assert len(paths) == len(set(paths))
+
+
+class TestPerCpuMemory:
+    """Per-CPU memory accounting for DelftBlue-style sites (issue #352)."""
+
+    def _orchestrator(self, cluster, res):
+        step = Step(block=lambda: None, name="create")
+        p = Pipeline(name="test", steps=[step])
+        return render_orchestrator_script(
+            pipeline=p,
+            cluster=cluster,
+            orchestrator_resources=res,
+            script_paths={"create": "/scripts/create.sh"},
+            log_dir_path="/logs",
+            job_dir=Path("/scratch/job1"),
+        )
+
+    def _step(self, cluster, res):
+        step = Step(block=lambda: None, name="train", resources=res)
+        return render_sbatch_script(
+            step=step,
+            cluster=cluster,
+            pipeline_name="pipe",
+            label="train",
+            job_dir=Path("/scratch/job1"),
+            iteration=0,
+        )
+
+    def test_step_mem_per_cpu_replaces_mem(self, cluster):
+        # When mem_per_cpu is set, emit --mem-per-cpu and NOT --mem
+        # (SLURM treats the two as mutually exclusive -> fatal).
+        res = SlurmResources(mem="8G", mem_per_cpu="3968M")
+        script = self._step(cluster, res)
+        assert "#SBATCH --mem-per-cpu=3968M" in script
+        assert "#SBATCH --mem=" not in script
+
+    def test_step_default_uses_mem(self, cluster):
+        # Without mem_per_cpu, --mem is used and --mem-per-cpu absent.
+        script = self._step(cluster, SlurmResources(mem="8G"))
+        assert "#SBATCH --mem=8G" in script
+        assert "#SBATCH --mem-per-cpu" not in script
+
+    def test_step_ntasks_custom_value(self, cluster):
+        script = self._step(cluster, SlurmResources(ntasks=4))
+        assert "#SBATCH --ntasks=4" in script
+
+    def test_step_nodes_omitted_when_mem_per_cpu_and_default_nodes(
+        self, cluster
+    ):
+        # mem_per_cpu set AND nodes at default 1 -> --nodes dropped.
+        res = SlurmResources(mem_per_cpu="3968M", nodes=1)
+        script = self._step(cluster, res)
+        assert "#SBATCH --nodes" not in script
+
+    def test_step_nodes_emitted_when_explicit_multinode(self, cluster):
+        # An explicit nodes > 1 is never silently dropped.
+        res = SlurmResources(mem_per_cpu="3968M", nodes=2)
+        script = self._step(cluster, res)
+        assert "#SBATCH --nodes=2" in script
+
+    def test_step_nodes_emitted_without_mem_per_cpu(self, cluster):
+        # Omission only applies under mem_per_cpu; the default path
+        # keeps --nodes=1.
+        script = self._step(cluster, SlurmResources(nodes=1))
+        assert "#SBATCH --nodes=1" in script
+
+    def test_orchestrator_mem_per_cpu_replaces_mem(self, cluster):
+        # The orchestrator header obeys the same rules, so a
+        # DelftBlue pipeline can make its orchestrator submittable
+        # via orchestrator_resources.
+        res = SlurmResources(time="00:10:00", mem="1G", mem_per_cpu="1024M")
+        script = self._orchestrator(cluster, res)
+        assert "#SBATCH --mem-per-cpu=1024M" in script
+        assert "#SBATCH --mem=" not in script
+        assert "#SBATCH --ntasks=1" in script
+        assert "#SBATCH --nodes" not in script
+
+    def test_orchestrator_default_uses_mem(self, cluster):
+        res = SlurmResources(time="00:10:00", mem="1G")
+        script = self._orchestrator(cluster, res)
+        assert "#SBATCH --mem=1G" in script
+        assert "#SBATCH --mem-per-cpu" not in script
+        assert "#SBATCH --ntasks=1" in script


### PR DESCRIPTION
## Summary

Fixes #352. The SLURM executor hard-coded per-node `--mem` + `--nodes` and never emitted `--ntasks`, so **every** job (orchestrator and every step) was rejected at submission time on sites whose `job_submit` filter mandates per-CPU memory accounting — notably **TU Delft's DelftBlue**. Because `--mem` and `--mem-per-cpu` are mutually exclusive (fatal) at every SLURM site, `extra_sbatch` could not work around it — the fix has to *omit* `--mem`, which only the renderer can do.

## Changes

- **`SlurmResources`** gains two fields: `ntasks: int = 1` and `mem_per_cpu: str | None = None`. When `mem_per_cpu` is set, `mem` is ignored (documented, not validated).
- **Both header renderers** (`render_sbatch_script`, `render_orchestrator_script`) now share one `_render_resource_directives(res)` helper so they cannot drift:
  - `--ntasks={res.ntasks}` is emitted **unconditionally** on every cluster (confirmed harmless on plain-SLURM sites like Oscar).
  - `--mem-per-cpu` replaces `--mem` when `mem_per_cpu` is set.
  - `--nodes` is omitted only when `mem_per_cpu` is set **and** `nodes == 1`; an explicit `nodes > 1` is always emitted.
- **[ADR 0003](docs/adr/0003-per-cpu-memory-accounting.md)** records the rationale, including the caveat that a DelftBlue pipeline must also override `Pipeline.orchestrator_resources` with a `mem_per_cpu` (the built-in orchestrator default stays per-node by design).
- Regenerated all 6 `tests/pipeline/golden/*.sh` (one `--ntasks=1` line each); extended `test_resources.py` and `test_slurm.py` (new `TestPerCpuMemory`); bumped version to **2.4.0**.

## Backward compatibility

`mem_per_cpu` defaults to `None`, so per-node `--mem` output is unchanged wherever it is not opted into. The only behavior change for existing configs is the added `--ntasks=1` line.

## Verification

- `uv run pytest` (full suite, `[tests,all]` extras + coverage gate): **1133 passed**, coverage **91.84%** (gate 85%).
- `pre-commit run --all-files`: passing (ruff format/check, toml-sort).
- **Live on DelftBlue** via `sbatch --test-only`: new step + orchestrator scripts **accepted** on `compute`; the old-style header **rejected** with the exact error from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
